### PR TITLE
Add header Access-Control-Allow-Origin: * to all GET responses

### DIFF
--- a/cnxarchive/__init__.py
+++ b/cnxarchive/__init__.py
@@ -59,8 +59,18 @@ class Application:
                 return controller
         return None
 
+    def add_cors(self, start_response):
+        """A start_response wrapper to add CORS header to GET requests
+        """
+        def r(status, headers, *args, **kwargs):
+            headers.append(('Access-Control-Allow-Origin', '*'))
+            start_response(status, headers, *args, **kwargs)
+        return r
+
     def __call__(self, environ, start_response):
         controller = self.route(environ)
+        if environ.get('REQUEST_METHOD', '') == 'GET':
+            start_response = self.add_cors(start_response)
         if controller is not None:
             try:
                 return controller(environ, start_response)

--- a/cnxarchive/tests.py
+++ b/cnxarchive/tests.py
@@ -1005,3 +1005,51 @@ class GetBuylinksTestCase(unittest.TestCase):
                 "('buyLink', 'http://buy-col11522.com/download')]")
         # Just assert that the script does not fail
         self.get_buylinks.main()
+
+
+class CORSTestCase(unittest.TestCase):
+    """Tests for correctly enabling CORS on the server
+    """
+
+    def start_response(self, *args, **kwargs):
+        self.args = args
+        self.kwargs = kwargs
+
+    def controller(self, environ, start_response):
+        status = '200 OK'
+        headers = [('Content-type', 'text/plain')]
+        start_response(status, headers)
+        return ['hello']
+
+    def test_get(self):
+        # We should have "Access-Control-Allow-Origin: *" in
+        # the headers
+        from . import Application
+        app = Application()
+        app.add_route('/', self.controller)
+        environ = {
+                'REQUEST_METHOD': 'GET',
+                'PATH_INFO': '/',
+                }
+        app(environ, self.start_response)
+        self.assertEqual(self.args, ('200 OK', [
+            ('Content-type', 'text/plain'),
+            ('Access-Control-Allow-Origin', '*'),
+            ]))
+        self.assertEqual(self.kwargs, {})
+
+    def test_post(self):
+        # We should not have "Access-Control-Allow-Origin: *" in
+        # the headers
+        from . import Application
+        app = Application()
+        app.add_route('/', self.controller)
+        environ = {
+                'REQUEST_METHOD': 'POST',
+                'PATH_INFO': '/',
+                }
+        app(environ, self.start_response)
+        self.assertEqual(self.args, ('200 OK', [
+            ('Content-type', 'text/plain'),
+            ]))
+        self.assertEqual(self.kwargs, {})


### PR DESCRIPTION
This fixes the problem of webview not able to access cnx-archive because
they are cross domain. (Close issue #20)

Version 2 of #28
