### PR TITLE
Add CORS headers for  preflighted requests

### DIFF
--- a/cnxarchive/__init__.py
+++ b/cnxarchive/__init__.py
@@ -64,12 +64,13 @@ class Application:
         """
         def r(status, headers, *args, **kwargs):
             headers.append(('Access-Control-Allow-Origin', '*'))
+            headers.append(('Access-Control-Allow-Methods', 'GET, OPTIONS'))
             start_response(status, headers, *args, **kwargs)
         return r
 
     def __call__(self, environ, start_response):
         controller = self.route(environ)
-        if environ.get('REQUEST_METHOD', '') == 'GET':
+        if environ.get('REQUEST_METHOD', '') in ['GET', 'OPTIONS']:
             start_response = self.add_cors(start_response)
         if controller is not None:
             try:

--- a/cnxarchive/tests.py
+++ b/cnxarchive/tests.py
@@ -1187,6 +1187,25 @@ class CORSTestCase(unittest.TestCase):
         self.assertEqual(self.args, ('200 OK', [
             ('Content-type', 'text/plain'),
             ('Access-Control-Allow-Origin', '*'),
+            ('Access-Control-Allow-Methods', 'GET, OPTIONS'),
+            ]))
+        self.assertEqual(self.kwargs, {})
+
+    def test_options(self):
+        # We should have "Access-Control-Allow-Origin: *" in the headers for
+        # preflighted requests
+        from . import Application
+        app = Application()
+        app.add_route('/', self.controller)
+        environ = {
+                'REQUEST_METHOD': 'OPTIONS',
+                'PATH_INFO': '/',
+                }
+        app(environ, self.start_response)
+        self.assertEqual(self.args, ('200 OK', [
+            ('Content-type', 'text/plain'),
+            ('Access-Control-Allow-Origin', '*'),
+            ('Access-Control-Allow-Methods', 'GET, OPTIONS'),
             ]))
         self.assertEqual(self.kwargs, {})
 


### PR DESCRIPTION
CORS headers are now sent for GET and OPTIONS requests.
