### PR TITLE
Add CORS headers for preflighted requests

### DIFF
--- a/cnxarchive/__init__.py
+++ b/cnxarchive/__init__.py
@@ -59,18 +59,22 @@ class Application:
                 return controller
         return None
 
-    def add_cors(self, start_response):
+    def add_cors(self, environ, start_response):
         """A start_response wrapper to add CORS header to GET requests
         """
         def r(status, headers, *args, **kwargs):
             headers.append(('Access-Control-Allow-Origin', '*'))
+            headers.append(('Access-Control-Allow-Methods', 'GET, OPTIONS'))
+            req_headers = environ.get('HTTP_ACCESS_CONTROL_REQUEST_HEADERS')
+            if req_headers:
+                headers.append(('Access-Control-Allow-Headers', req_headers))
             start_response(status, headers, *args, **kwargs)
         return r
 
     def __call__(self, environ, start_response):
         controller = self.route(environ)
-        if environ.get('REQUEST_METHOD', '') == 'GET':
-            start_response = self.add_cors(start_response)
+        if environ.get('REQUEST_METHOD', '') in ['GET', 'OPTIONS']:
+            start_response = self.add_cors(environ, start_response)
         if controller is not None:
             try:
                 return controller(environ, start_response)

--- a/cnxarchive/tests.py
+++ b/cnxarchive/tests.py
@@ -1187,6 +1187,29 @@ class CORSTestCase(unittest.TestCase):
         self.assertEqual(self.args, ('200 OK', [
             ('Content-type', 'text/plain'),
             ('Access-Control-Allow-Origin', '*'),
+            ('Access-Control-Allow-Methods', 'GET, OPTIONS'),
+            ]))
+        self.assertEqual(self.kwargs, {})
+
+    def test_options(self):
+        # We should have "Access-Control-Allow-Origin: *" in the headers for
+        # preflighted requests
+        from . import Application
+        app = Application()
+        app.add_route('/', self.controller)
+        environ = {
+                'REQUEST_METHOD': 'OPTIONS',
+                'PATH_INFO': '/',
+                'HTTP_ACCESS_CONTROL_REQUEST_HEADERS':
+                'origin, accept-encoding, accept-language, cache-control'
+                }
+        app(environ, self.start_response)
+        self.assertEqual(self.args, ('200 OK', [
+            ('Content-type', 'text/plain'),
+            ('Access-Control-Allow-Origin', '*'),
+            ('Access-Control-Allow-Methods', 'GET, OPTIONS'),
+            ('Access-Control-Allow-Headers',
+                'origin, accept-encoding, accept-language, cache-control'),
             ]))
         self.assertEqual(self.kwargs, {})
 


### PR DESCRIPTION
CORS headers are now sent for GET and OPTIONS requests.

Access-Control-Allow-Headers is not allowed to be \* so just echo the
content of the request header Access-Control-Request-Headers

Should fix issue #45
