### PR TITLE
Return author's full name in search results limits instead of id

### DIFF
--- a/cnxarchive/search.py
+++ b/cnxarchive/search.py
@@ -280,7 +280,7 @@ class QueryResults(Sequence):
         counts = {}
         for rec in self._records:
             for author in rec['authors']:
-                uid = author['id']
+                uid = author['fullname']
                 counts.setdefault(uid, 0)
                 counts[uid] += 1
         return counts

--- a/cnxarchive/tests/test_search.py
+++ b/cnxarchive/tests/test_search.py
@@ -88,7 +88,7 @@ class SearchModelTestCase(unittest.TestCase):
         self.assertEqual(results.counts['mediaType'][COLLECTION_MIMETYPE], 1)
         # Check the author counts
         self.assertEqual(results.counts['author'],
-                         {u'e5a07af6-09b9-4b74-aa7a-b7510bee90b8': 15})
+                         {u'OpenStax College': 15})
         # Check counts for publication year.
         self.assertEqual(results.counts['pubYear'], {u'2013': 15})
         # Check the subject counts.

--- a/cnxarchive/tests/test_views.py
+++ b/cnxarchive/tests/test_views.py
@@ -319,7 +319,7 @@ SEARCH_RESULTS = {
         u'total': 2,
         u'limits': [
             {u'count': 2, u'pubYear': u'2013'},
-            {u'author': u'e5a07af6-09b9-4b74-aa7a-b7510bee90b8',
+            {u'author': u'OpenStax College',
              u'count': 2},
             {u'count': 1,
              u'mediaType': u'application/vnd.org.cnx.collection'},


### PR DESCRIPTION
See #90

It used to look like this:

```
{"author": "e5a07af6-09b9-4b74-aa7a-b7510bee90b8", "count": 2}
```

Now it looks like this:

```
{"author": "OpenStax College", "count": 2}
```
