### PR TITLE
Generate subject list for webview in "config" API

### DIFF
--- a/cnxarchive/__init__.py
+++ b/cnxarchive/__init__.py
@@ -115,6 +115,7 @@ def main(global_config, **settings):
     app.add_route('/exports/{ident_hash}.{type}', 'cnxarchive.views:get_export')
     app.add_route('/extra/{ident_hash}', 'cnxarchive.views:get_extra')
     app.add_route('/search', 'cnxarchive.views:search')
+    app.add_route('/config', 'cnxarchive.views:get_config')
 
     mandatory_settings = ['exports-directories', 'exports-allowable-types']
     for setting in mandatory_settings:

--- a/cnxarchive/database.py
+++ b/cnxarchive/database.py
@@ -43,6 +43,7 @@ SQL = {
     'get-resource-by-filename': _read_sql_file('get-resource-by-filename'),
     'get-tree-by-uuid-n-version': _read_sql_file('get-tree-by-uuid-n-version'),
     'get-module-versions': _read_sql_file('get-module-versions'),
+    'get-subject-list': _read_sql_file('get-subject-list'),
     }
 
 

--- a/cnxarchive/sql/get-subject-list.sql
+++ b/cnxarchive/sql/get-subject-list.sql
@@ -1,0 +1,12 @@
+-- ###
+-- Copyright (c) 2013, Rice University
+-- This software is subject to the provisions of the GNU Affero General
+-- Public License version 3 (AGPLv3).
+-- See LICENCE.txt for details.
+-- ###
+
+-- arguments:
+SELECT tagid, tag as tags
+FROM tags
+WHERE scheme != 'internal'
+ORDER BY tag;

--- a/cnxarchive/tests/test_views.py
+++ b/cnxarchive/tests/test_views.py
@@ -900,3 +900,20 @@ class ViewsTestCase(unittest.TestCase):
                         ],
                 }
             })
+
+        def test_get_config(self):
+            # Build the request
+            environ = self._make_environ()
+
+            # Call the view
+            from ..views import get_config
+            config = get_config(environ, self._start_response)[0]
+            config = json.loads(config)
+            self.assertEqual(config, {
+                u'subjects': [{'id': 1, u'name': u'Arts'},
+                              {'id': 2, u'name': u'Business'},
+                              {'id': 3, u'name': u'Humanities'},
+                              {'id': 4, u'name': u'Mathematics and Statistics'},
+                              {'id': 5, u'name': u'Science and Technology'},
+                              {'id': 6, u'name': u'Social Sciences'},
+                })

--- a/cnxarchive/views.py
+++ b/cnxarchive/views.py
@@ -317,3 +317,20 @@ def search(environ, start_response):
     headers = [('Content-type', 'application/json')]
     start_response(status, headers)
     return [json.dumps(results)]
+
+def get_config(environ, start_response):
+    """Return a dict with config values for webview
+    """
+    settings = get_settings()
+    with psycopg2.connect(settings[CONNECTION_SETTINGS_KEY]) as db_connection:
+        with db_connection.cursor() as cursor:
+            cursor.execute(SQL['get-subject-list'])
+            subjects = [{'id': s[0], 'name': s[1]} for s in cursor.fetchall()]
+    config = {
+            'subjects': subjects,
+            }
+
+    status = '200 OK'
+    headers = [('Content-type', 'application/json')]
+    start_response(status, headers)
+    return [json.dumps(config)]


### PR DESCRIPTION
Going to http://localhost:6543/config will return this:

```
{
  "subjects": [
    {"id": 1, "name": "Arts"},
    {"id": 2, "name": "Business"},
    {"id": 3, "name": "Humanities"},
    {"id": 4, "name": "Mathematics and Statistics"},
    {"id": 5, "name": "Science and Technology"},
    {"id": 6, "name": "Social Sciences"}
  ]
}
```
