### PR TITLE
Search filters

### DIFF
--- a/cnxarchive/search.py
+++ b/cnxarchive/search.py
@@ -26,7 +26,7 @@ __all__ = ('search', 'Query',)
 
 
 WILDCARD_KEYWORD = 'text'
-VALID_FILTER_KEYWORDS = ('type', 'pubYear',)
+VALID_FILTER_KEYWORDS = ('type', 'pubYear', 'authorId',)
 SORT_VALUES_MAPPING = {
     'pubdate': 'created DESC',
     'version': 'version DESC',
@@ -332,10 +332,13 @@ def _transmute_filter(keyword, value):
         else:
             raise ValueError("Invalid filter value '{}' for filter '{}'." \
                                  .format(value, keyword))
-        return ('portal_type', type_name)
+        return ('portal_type = %({})s', type_name)
 
     elif keyword == 'pubYear':
-        return ('extract(year from created)', int(value))
+        return ('extract(year from created) = %({})s', int(value))
+
+    elif keyword == 'authorId':
+        return ('%({})s = ANY(authors)', value)
 
 
 def _transmute_sort(sort_value):
@@ -425,12 +428,12 @@ def _build_search(structured_query, weights):
             # These key values are special in that they don't,
             #   directly translate to SQL fields and values.
             try:
-                field_name, match_value = _transmute_filter(keyword, value)
+                filter_stmt, match_value = _transmute_filter(keyword, value)
             except ValueError:
                 del structured_query.filters[i]
                 continue
             arguments[arg_name] = match_value
-            filter_stmt = "{} = %({})s".format(field_name, arg_name)
+            filter_stmt = filter_stmt.format(arg_name)
             filters.append(filter_stmt)
     filters = ' AND '.join(filters)
     # Add the arguments for sorting.

--- a/cnxarchive/sql/search/README.rst
+++ b/cnxarchive/sql/search/README.rst
@@ -46,7 +46,7 @@ The list of keyword specific search fields is as follows:
 
 Filters are keywords as well,
 except that they only support a limited set of values.
-There are currently two search filters: ``type`` and ``pubYear``.
+There are currently three search filters: ``type``, ``pubYear`` and ``authorId``.
 The type filter is used to further filter keyword searches.
 The possible values for the type field are ``book`` and ``page``.
 It is assumed that if the type field is absent, all types are viable.

--- a/cnxarchive/tests/test_search.py
+++ b/cnxarchive/tests/test_search.py
@@ -417,6 +417,16 @@ class SearchTestCase(unittest.TestCase):
         result_ids = [r['id'] for r in results]
         self.assertEqual(len(results), 0)
 
+    def test_authorId_filter(self):
+        # Filter results by author "OSC Physics Maintainer"
+        query_params = [('text', 'physics'),
+                        ('authorId', '1df3bab1-1dc7-4017-9b3a-960a87e706b1')]
+
+        results = self.call_target(query_params)
+        result_ids = [r['id'] for r in results]
+        self.assertEqual(len(results), 1)
+        self.assertEqual(result_ids, ['209deb1f-1a46-4369-9e0d-18674cf58a3e'])
+
     def test_sort_filter_on_pubdate(self):
         # Test the sorting of results by publication date.
         query_params = [('text', 'physics'), ('sort', 'pubDate')]


### PR DESCRIPTION
Should fix #103.

Add ability to filter search results by pubYear and authorId, for example:

`/search?q=physics+pubYear:2012`

`/search?q=physics+authorId:1df3bab1-1dc7-4017-9b3a-960a87e706b1`

Note: The test in cnxarchive.tests.test_scripts_hits_counter.HitsCounterTestCase is failing because the test data is older than a week and we're no longer adding the data to the recent_hit_ranks table.  I haven't found a way to fix it yet...
