### PR TITLE
Rename /extra API to /extras to keep it consistent with other APIs

### DIFF
--- a/cnxarchive/__init__.py
+++ b/cnxarchive/__init__.py
@@ -113,7 +113,7 @@ def main(global_config, **settings):
     app.add_route('/contents/{ident_hash}', 'cnxarchive.views:get_content')
     app.add_route('/resources/{hash}', 'cnxarchive.views:get_resource')
     app.add_route('/exports/{ident_hash}.{type}', 'cnxarchive.views:get_export')
-    app.add_route('/extra/{ident_hash}', 'cnxarchive.views:get_extra')
+    app.add_route('/extras/{ident_hash}', 'cnxarchive.views:get_extra')
     app.add_route('/search', 'cnxarchive.views:search')
     app.add_route('/config', 'cnxarchive.views:get_config')
 

--- a/cnxarchive/tests/test_views.py
+++ b/cnxarchive/tests/test_views.py
@@ -751,7 +751,7 @@ class ViewsTestCase(unittest.TestCase):
         with self.assertRaises(httpexceptions.HTTPFound) as raiser:
             get_extra(environ, self._start_response)
         exception = raiser.exception
-        expected_location = "/extra/{}".format(expected_ident_hash)
+        expected_location = "/extras/{}".format(expected_ident_hash)
         self.assertEqual(exception.headers,
                          [('Location', expected_location)])
 

--- a/cnxarchive/views.py
+++ b/cnxarchive/views.py
@@ -232,7 +232,7 @@ def get_extra(environ, start_response):
     with psycopg2.connect(settings[CONNECTION_SETTINGS_KEY]) as db_connection:
         with db_connection.cursor() as cursor:
             if not version:
-                redirect_to_latest(cursor, id, '/extra/{}@{}')
+                redirect_to_latest(cursor, id, '/extras/{}@{}')
             results['downloads'] = list(get_export_allowable_types(cursor,
                 exports_dirs, id, version))
             results['isLatest'] = is_latest(cursor, id, version)


### PR DESCRIPTION
@dak when this is merged, you'll need to update webview to use `/extras` .  Thanks!
