### PR TITLE
Add test for searching by subject only

### DIFF
--- a/cnxarchive/tests/test_views.py
+++ b/cnxarchive/tests/test_views.py
@@ -798,6 +798,28 @@ class ViewsTestCase(unittest.TestCase):
         for i in results:
             self.assertEqual(results[i], SEARCH_RESULTS[i])
 
+    def test_search_only_subject(self):
+        # From the Content page, we have a list of subjects (tags),
+        # they link to the search page like: /search?q=subject:"Arts"
+
+        # Build the request
+        environ = self._make_environ()
+        environ['QUERY_STRING'] = 'q=subject:"Science and Technology"'
+
+        from ..views import search
+        results = search(environ, self._start_response)[0]
+        status = self.captured_response['status']
+        headers = self.captured_response['headers']
+
+        self.assertEqual(status, '200 OK')
+        self.assertEqual(headers[0], ('Content-type', 'application/json'))
+        results = json.loads(results)
+
+        self.assertEqual(results['query'], {
+            u'limits': [{u'subject': u'Science and Technology'}],
+            u'sort': []})
+        self.assertEqual(results['results']['total'], 7)
+
     def test_search_highlight_abstract(self):
         # Build the request
         environ = self._make_environ()


### PR DESCRIPTION
@reedstrm: I know you recently created a pull request for searching by subject:
- make subject a limit search - allow linit-only searchs
- make subject a limit search - allow linit-only searchs
- Merge branch 'limit-only-search' of github.com:Connexions/cnx-archive into limit-only-search
- make the subject/tag limit join conditional, to avoid excess rows on non-limit searches
- more created/revised fixes in tests
- Merge pull request #130 from Connexions/limit-only-search

I tried to write a test that would break before your changes and pass after.  But the test I wrote already passes before your changes.  That probably means that I'm testing the wrong thing.  Could you have a look and let me know?
