### PR TITLE
WIP Fix error: Namespace prefix m on math is not defined

### DIFF
--- a/cnxarchive/tests/data/m10730-2.1.cnxml
+++ b/cnxarchive/tests/data/m10730-2.1.cnxml
@@ -1,0 +1,298 @@
+<?xml version="1.0" standalone="no"?>
+<!DOCTYPE module PUBLIC "-//CNX//DTD CNXML 0.4 plus MathML//EN" "http://cnx.rice.edu/cnxml/0.4/DTD/cnxml_mathml.dtd">
+
+<module id='effectivelength'>
+  <name>Effective Length</name>
+  <metadata xmlns:md="http://cnx.rice.edu/mdml/0.4">
+  <md:version>2.1</md:version>
+  <md:created>2002/07/10</md:created>
+  <md:revised>2003-01-13</md:revised>
+  <md:authorlist>
+    <md:author id="Joanna">
+      <md:firstname>Joanna</md:firstname>
+      
+      <md:surname>Gonzalez</md:surname>
+      <md:email>joannag@owlnet.rice.edu</md:email>
+    </md:author>
+  </md:authorlist>
+
+  <md:maintainerlist>
+    <md:maintainer id="Joanna">
+      <md:firstname>Joanna</md:firstname>
+      
+      <md:surname>Gonzalez</md:surname>
+      <md:email>joannag@owlnet.rice.edu</md:email>
+    </md:maintainer>
+  </md:maintainerlist>
+  
+  <md:keywordlist>
+    <md:keyword>effective length</md:keyword>
+    <md:keyword>K</md:keyword>
+  </md:keywordlist>
+
+  <md:abstract>(Blank Abstract)</md:abstract>
+</metadata>
+
+  <content>
+
+   <section id='defines'>
+    <name>Define effective length</name>
+    <para id='define'>
+     The equations for critical buckling load include the variable KL which is the <emphasis>effective length</emphasis>.  K is the <emphasis>effective length factor</emphasis>.  Values for <emphasis>K</emphasis> vary depending on the load and type of supports of a member.  A listing of the values can be found in the <emphasis>Manual</emphasis> on page <term>16.1-189</term> in Table C-C2.1.  For instance, the value for <emphasis>K</emphasis> with the condition that both ends of a column are rotation free and translation fixed (pinned) is 1.0.
+    </para>
+   </section>
+
+   <section id='sconservative'>
+    <name>Technical vs. recommended values of K</name>
+    <para id='conservative'>
+     "Two values for <emphasis>K</emphasis> are given: a theoretical value and a recommended design value to be used when the ideal end condition is approximated.  Hence, unless a 'fixed' end is perfectly fixed, the more conservative design values are to be used.  Only under the most extraordinary circumstances would the use of the theoretical values be justified.  Note, however, that the theoretical and recommended design values are the same for conditions (d) and (f) in the Commentary Table C-C2.1.  The reason is that any deviation from a perfectly frictionless hinge or pin introduces rotational restraint and tends to reduce <emphasis>K</emphasis>.  Therefore use of the theoretical values in these two cases is conservative."
+    <cite>LRFD Steel Design Second Edition: William T. Segui, 1999</cite>
+    </para>
+
+    <para id='note'>
+     <note type='note'>The larger the effective length, the less strength there is in a column.  So, if there is a choice of effective lengths, the larger value will give the more conservative strength value.</note>
+    </para>
+   </section>
+
+   <section id='smore'>
+    <name>Actual length vs. effective length</name>
+    <para id='more'>
+     Sometimes the actual length of a member differs from the effective length.  This is true when a member is supported somewhere in the middle in addition to at the two ends.  The effective length then, is the length from one support to another.  Also, a member can be supported two different ways in two different axes.  For example, a column can be supported at the top in the bottom while looking at it in the x-direction, but braced in the middle when looking at it from the y-direction.  We refer to the distance between the supports in the y-direction and the x-direction as 
+    <m:math>
+     <m:ci>
+      <m:msub>
+       <m:mi>L</m:mi>
+       <m:mi>y</m:mi>
+      </m:msub>
+     </m:ci>
+    </m:math>
+    and 
+    <m:math>
+     <m:ci>
+      <m:msub>
+       <m:mi>L</m:mi>
+       <m:mi>x</m:mi>
+      </m:msub>
+     </m:ci>
+    </m:math>
+    , respectively.
+    </para>
+   </section>
+
+   <section id='skl'>
+    <name>Using KL(x)</name>
+    <para id='para'>
+     The design strengths given in the column load tables beginning on page <term>4-21</term> are based on the effective length with respect to the y-axis.  A procedure was developed (as follows) to use
+     <m:math>
+      <m:apply>
+       <m:times/>
+        <m:ci>
+         <m:msub>
+          <m:mi>K</m:mi>
+          <m:mi>x</m:mi>
+         </m:msub>
+        </m:ci>
+        <m:ci>L</m:ci>
+      </m:apply>
+     </m:math>
+        
+
+    in the tabulated values.  
+    </para>   
+
+    <para id='tab'>
+     The tablulated values in chapter 4 of the <emphasis>Manual</emphasis> are in terms of the y-axis being the stong axis.  This means they are based on the values of KL being equal to KyL.  However, if a situation occurs where one would need the values of KL with respect to the x-axis, the following procedure can be used.
+    </para>
+
+    <para id='eqns'>
+     The KL as tabulated is equal to either 
+     <m:math>
+      <m:apply>
+       <m:times/>
+        <m:ci>
+         <m:msub>
+          <m:mi>K</m:mi>
+          <m:mi>y</m:mi>
+         </m:msub>
+        </m:ci>
+        <m:ci>L</m:ci>
+      </m:apply>
+     </m:math>
+     or 
+     <m:math>
+      <m:apply>
+       <m:divide/>
+        <m:apply>
+         <m:times/>
+          <m:ci>
+           <m:msub>
+            <m:mi>K</m:mi>
+            <m:mi>x</m:mi>
+           </m:msub>
+          </m:ci>
+          <m:ci>L</m:ci>
+        </m:apply>
+        <m:apply>
+         <m:times/>
+          <m:ci>
+           <m:msub>
+            <m:mi>r</m:mi>
+            <m:mi>x</m:mi>
+           </m:msub>
+          </m:ci>
+          <m:ci>/</m:ci>
+          <m:ci>
+           <m:msub>
+            <m:mi>r</m:mi>
+            <m:mi>y</m:mi>
+           </m:msub>
+          </m:ci>
+        </m:apply>
+       </m:apply>
+      </m:math>
+        .  We can obtain 
+     <m:math>
+      <m:apply>
+       <m:divide/>
+        <m:apply>
+         <m:times/>
+          <m:ci>
+           <m:msub>
+            <m:mi>K</m:mi>
+            <m:mi>x</m:mi>
+           </m:msub>
+          </m:ci>
+          <m:ci>L</m:ci>
+        </m:apply>
+        <m:apply>
+         <m:times/>
+          <m:ci>
+           <m:msub>
+            <m:mi>r</m:mi>
+            <m:mi>x</m:mi>
+           </m:msub>
+          </m:ci>
+          <m:ci>/</m:ci>
+          <m:ci>
+           <m:msub>
+            <m:mi>r</m:mi>
+            <m:mi>y</m:mi>
+           </m:msub>
+          </m:ci>
+        </m:apply>
+      </m:apply>
+     </m:math>
+        by:
+        <list type='enumerated' id='list1'>
+         <item>
+          <m:math>
+           <m:apply>
+            <m:eq/>
+             <m:apply>
+              <m:divide/>
+               <m:ci>(KL)y</m:ci>
+               <m:ci>
+                <m:msub>
+                 <m:mi>r</m:mi>
+                 <m:mi>y</m:mi>
+                </m:msub>
+               </m:ci>
+             </m:apply>
+           </m:apply>
+          </m:math>   
+         </item>
+         <item>
+          <m:math>
+           <m:apply>
+            <m:eq/>
+             <m:ci>y</m:ci>
+             <m:apply>
+              <m:divide/>
+               <m:ci>
+                <m:msub>
+                 <m:mi>r</m:mi>
+                 <m:mi>y</m:mi>
+                </m:msub>
+               </m:ci>
+               <m:ci>
+                <m:msub>
+                 <m:mi>r</m:mi>
+                 <m:mi>x</m:mi>
+                </m:msub>
+               </m:ci>
+             </m:apply>
+           </m:apply>
+          </m:math>
+         </item>
+         <item>
+          <m:math>
+           <m:apply>
+            <m:eq/>
+             <m:ci>(KL)y</m:ci>
+             <m:apply>
+                <m:times/>
+                 <m:ci>KL</m:ci>
+                 <m:apply>
+                  <m:divide/>
+                   <m:ci>
+                    <m:msub>
+                     <m:mi>r</m:mi>
+                     <m:mi>y</m:mi>
+                    </m:msub>
+                   </m:ci>
+                   <m:ci>
+                    <m:msub>
+                     <m:mi>r</m:mi>
+                     <m:mi>x</m:mi>
+                    </m:msub>
+                   </m:ci>
+                 </m:apply>
+               </m:apply>
+           </m:apply>
+          </m:math>
+         </item>
+         <item>
+          <m:math>
+<m:apply>
+<m:eq/>
+           <m:apply>
+            <m:divide/>
+             <m:apply>
+              <m:times/>
+               <m:ci>
+                <m:msub>
+                 <m:mi>K</m:mi>
+                 <m:mi>x</m:mi>
+                </m:msub>
+               </m:ci>
+               <m:ci>L</m:ci>
+             </m:apply>
+             <m:apply>
+              <m:times/>
+               <m:ci>
+                <m:msub>
+                 <m:mi>r</m:mi>
+                 <m:mi>x</m:mi>
+                </m:msub>
+               </m:ci>
+               <m:ci>/</m:ci>
+               <m:ci>
+                <m:msub>
+                 <m:mi>r</m:mi>
+                 <m:mi>y</m:mi>
+                </m:msub>
+               </m:ci>
+             </m:apply>
+           </m:apply>
+<m:ci>(KL)y</m:ci>
+</m:apply>
+          </m:math>
+         </item>          
+        </list>
+
+    </para>
+   </section>
+  </content>
+  
+</module>
+

--- a/cnxarchive/tests/data/m10730-2.1.html
+++ b/cnxarchive/tests/data/m10730-2.1.html
@@ -1,0 +1,299 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<html xmlns="http://www.w3.org/1999/xhtml">
+
+
+  Effective Length
+  
+  2.1
+  2002/07/10
+  2003-01-13
+  
+    
+      Joanna
+      
+      Gonzalez
+      joannag@owlnet.rice.edu
+    
+  
+
+  
+    
+      Joanna
+      
+      Gonzalez
+      joannag@owlnet.rice.edu
+    
+  
+  
+  
+    effective length
+    K
+  
+
+  (Blank Abstract)
+
+
+  
+
+   
+    Define effective length
+    
+     The equations for critical buckling load include the variable KL which is the effective length.  K is the effective length factor.  Values for K vary depending on the load and type of supports of a member.  A listing of the values can be found in the Manual on page 16.1-189 in Table C-C2.1.  For instance, the value for K with the condition that both ends of a column are rotation free and translation fixed (pinned) is 1.0.
+    
+   
+
+   
+    Technical vs. recommended values of K
+    
+     "Two values for K are given: a theoretical value and a recommended design value to be used when the ideal end condition is approximated.  Hence, unless a 'fixed' end is perfectly fixed, the more conservative design values are to be used.  Only under the most extraordinary circumstances would the use of the theoretical values be justified.  Note, however, that the theoretical and recommended design values are the same for conditions (d) and (f) in the Commentary Table C-C2.1.  The reason is that any deviation from a perfectly frictionless hinge or pin introduces rotational restraint and tends to reduce K.  Therefore use of the theoretical values in these two cases is conservative."
+    LRFD Steel Design Second Edition: William T. Segui, 1999
+    
+
+    
+     The larger the effective length, the less strength there is in a column.  So, if there is a choice of effective lengths, the larger value will give the more conservative strength value.
+    
+   
+
+   
+    Actual length vs. effective length
+    
+     Sometimes the actual length of a member differs from the effective length.  This is true when a member is supported somewhere in the middle in addition to at the two ends.  The effective length then, is the length from one support to another.  Also, a member can be supported two different ways in two different axes.  For example, a column can be supported at the top in the bottom while looking at it in the x-direction, but braced in the middle when looking at it from the y-direction.  We refer to the distance between the supports in the y-direction and the x-direction as 
+    
+     
+      
+       L
+       y
+      
+     
+    
+    and 
+    
+     
+      
+       L
+       x
+      
+     
+    
+    , respectively.
+    
+   
+
+   
+    Using KL(x)
+    
+     The design strengths given in the column load tables beginning on page 4-21 are based on the effective length with respect to the y-axis.  A procedure was developed (as follows) to use
+     
+      
+       
+        
+         
+          K
+          x
+         
+        
+        L
+      
+     
+        
+
+    in the tabulated values.  
+       
+
+    
+     The tablulated values in chapter 4 of the Manual are in terms of the y-axis being the stong axis.  This means they are based on the values of KL being equal to KyL.  However, if a situation occurs where one would need the values of KL with respect to the x-axis, the following procedure can be used.
+    
+
+    
+     The KL as tabulated is equal to either 
+     
+      
+       
+        
+         
+          K
+          y
+         
+        
+        L
+      
+     
+     or 
+     
+      
+       
+        
+         
+          
+           
+            K
+            x
+           
+          
+          L
+        
+        
+         
+          
+           
+            r
+            x
+           
+          
+          /
+          
+           
+            r
+            y
+           
+          
+        
+       
+      
+        .  We can obtain 
+     
+      
+       
+        
+         
+          
+           
+            K
+            x
+           
+          
+          L
+        
+        
+         
+          
+           
+            r
+            x
+           
+          
+          /
+          
+           
+            r
+            y
+           
+          
+        
+      
+     
+        by:
+        
+         
+          
+           
+            
+             
+              
+               (KL)y
+               
+                
+                 r
+                 y
+                
+               
+             
+           
+             
+         
+         
+          
+           
+            
+             y
+             
+              
+               
+                
+                 r
+                 y
+                
+               
+               
+                
+                 r
+                 x
+                
+               
+             
+           
+          
+         
+         
+          
+           
+            
+             (KL)y
+             
+                
+                 KL
+                 
+                  
+                   
+                    
+                     r
+                     y
+                    
+                   
+                   
+                    
+                     r
+                     x
+                    
+                   
+                 
+               
+           
+          
+         
+         
+          
+
+
+           
+            
+             
+              
+               
+                
+                 K
+                 x
+                
+               
+               L
+             
+             
+              
+               
+                
+                 r
+                 x
+                
+               
+               /
+               
+                
+                 r
+                 y
+                
+               
+             
+           
+(KL)y
+
+          
+                   
+        
+
+    
+   
+  
+  
+
+
+</html>

--- a/cnxarchive/tests/test_to_html.py
+++ b/cnxarchive/tests/test_to_html.py
@@ -29,19 +29,23 @@ class TransformTests(unittest.TestCase):
         # Case to test the transformation of cnxml to html.
         # FIXME This transformation shouldn't even be in this package.
 
-        index_xml_filepath = os.path.join(TESTING_DATA_DIR,
-                                          'm42033-1.3.cnxml')
-        index_html_filepath = os.path.join(TESTING_DATA_DIR,
-                                           'm42033-1.3.html')
+        filenames_to_test = ['m42033-1.3', 'm10730-2.1']
 
-        with open(index_xml_filepath, 'r') as fp:
-            index_xml = fp.read()
-        from ..to_html import transform_cnxml_to_html
-        index_html = transform_cnxml_to_html(index_xml)
+        for filename in filenames_to_test:
 
-        with open(index_html_filepath, 'r') as fp:
-            expected_result = fp.read()
-        self.assertMultiLineEqual(index_html, expected_result)
+            index_xml_filepath = os.path.join(TESTING_DATA_DIR,
+                                              '{}.cnxml'.format(filename))
+            index_html_filepath = os.path.join(TESTING_DATA_DIR,
+                                               '{}.html'.format(filename))
+
+            with open(index_xml_filepath, 'r') as fp:
+                index_xml = fp.read()
+            from ..to_html import transform_cnxml_to_html
+            index_html = transform_cnxml_to_html(index_xml)
+
+            with open(index_html_filepath, 'r') as fp:
+                expected_result = fp.read()
+            self.assertMultiLineEqual(index_html, expected_result)
 
 
 class ToHtmlTestCase(unittest.TestCase):

--- a/cnxarchive/to_html.py
+++ b/cnxarchive/to_html.py
@@ -232,12 +232,20 @@ class ReferenceResolver:
 
 fix_reference_urls = ReferenceResolver.fix_reference_urls
 
+def fixup_cnxml(cnxml):
+    """Fix up cnxml so transformation will work
+    """
+    if '<m:' in cnxml and 'xmlns:m=' not in cnxml:
+        # To fix "Namespace prefix m on math is not defined",
+        # remove the prefix
+        cnxml = cnxml.replace('<m:', '<').replace('</m:', '</')
+    return cnxml
 
 def transform_cnxml_to_html(cnxml):
     """Transforms raw cnxml content to html."""
     xml_parser = etree.XMLParser(resolve_entities=False)
     gen_xsl = lambda f: etree.XSLT(etree.parse(f))
-    cnxml = etree.parse(BytesIO(cnxml), xml_parser)
+    cnxml = etree.parse(BytesIO(fixup_cnxml(cnxml)), xml_parser)
 
     # Transform the content to html.
     cnxml_to_html_filepath = os.path.join(XSL_DIRECTORY, 'cnxml-to-html5.xsl')


### PR DESCRIPTION
Note: Please do not merge.

I've created a string manipulation function `fixup_cnxml` to try to remove the error before we use lxml.etree.  Is this the right place to fix this?

I have thought of two ways to fix "Namespace prefix m on math is not defined":
- as below, remove the prefix
- add `"xmlns:m="http://www.w3.org/1998/Math/MathML"` to &lt;content&gt;.  (But some modules don't have &lt;content&gt;)

I don't really know what's right.  They give different html outputs.
