### PR TITLE
Make the search type filter case insensitive

### DIFF
--- a/cnxarchive/search.py
+++ b/cnxarchive/search.py
@@ -373,6 +373,7 @@ def _transmute_filter(keyword, value):
         raise ValueError("Invalid filter keyword '{}'.".format(keyword))
 
     if keyword == 'type':
+        value = value.lower()
         if value in ['book', 'collection']:
             type_name = 'Collection'
         elif value in ['page', 'module']:

--- a/cnxarchive/tests/test_search.py
+++ b/cnxarchive/tests/test_search.py
@@ -389,6 +389,14 @@ class SearchTestCase(unittest.TestCase):
         self.assertNotIn('e79ffde3-7fb4-4af3-9ec8-df648b391597',
                          result_ids)
 
+    def test_type_filter_case_insensitive(self):
+        query_params = [('text', 'physics'), ('type', 'Book')]
+
+        results = self.call_target(query_params)
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0]['id'],
+                         'e79ffde3-7fb4-4af3-9ec8-df648b391597')
+
     def test_type_filter_on_unknown(self):
         # Test for type filtering on an unknown type.
         query_params = [('text', 'physics'), ('type', 'image')]


### PR DESCRIPTION
Searching for type:Book should work the same as searching for type:book.

Fixes #162

Effort points: 1
