### PR TITLE
Schema initialization precheck with specific message. Closes #148

### DIFF
--- a/cnxarchive/sql/schema/schema.sql
+++ b/cnxarchive/sql/schema/schema.sql
@@ -1,5 +1,15 @@
 BEGIN WORK;
 
+DO LANGUAGE plpgsql
+$$
+BEGIN
+  IF EXISTS (SELECT 1 FROM pg_class WHERE relname='modules') THEN
+    RAISE EXCEPTION USING MESSAGE = 'Database is already initialized.';
+  END IF;
+END;
+$$;
+
+
 CREATE EXTENSION IF NOT EXISTS plpythonu;
 CREATE FUNCTION uuid_generate_v4 () RETURNS uuid LANGUAGE plpythonu AS $$ import uuid; return uuid.uuid4() $$ ;
 

--- a/cnxarchive/tests/test_database.py
+++ b/cnxarchive/tests/test_database.py
@@ -13,6 +13,29 @@ import psycopg2
 from . import *
 
 
+class InitializeDBTestCase(unittest.TestCase):
+    fixture = postgresql_fixture
+
+    @db_connect
+    def setUp(self, cursor):
+        self.fixture.setUp()
+
+    def tearDown(self):
+        self.fixture.tearDown()
+
+    def test_initdb_on_already_initialized_db(self):
+        # Case for testing the `initdb` raises a discernible error
+        #   when the the database is already initialized.
+        # The fixture has initialized the database, so we only need to
+        #   run the function.
+        from ..database import initdb
+        settings = get_app_settings(TESTING_CONFIG)
+        with self.assertRaises(psycopg2.InternalError) as caught_exception:
+            initdb(settings)
+        self.assertEqual(caught_exception.exception.message,
+                         'Database is already initialized.\n')
+
+
 class MiscellaneousFunctionsTestCase(unittest.TestCase):
     fixture = postgresql_fixture
 


### PR DESCRIPTION
This does change the schema file but not the schema itself. This simply introduces a more specific exception when the database appears to already exist. See #148 for more detail.
