### PR TITLE
add @version to id for search results

### DIFF
--- a/cnxarchive/tests/test_views.py
+++ b/cnxarchive/tests/test_views.py
@@ -237,7 +237,7 @@ SEARCH_RESULTS = {
         u'items': [
             {u'authors': [u'e5a07af6-09b9-4b74-aa7a-b7510bee90b8'],
              u'bodySnippet': None,
-             u'id': u'e79ffde3-7fb4-4af3-9ec8-df648b391597',
+             u'id': u'e79ffde3-7fb4-4af3-9ec8-df648b391597@7.1',
              u'keywords': [u'college physics',
                            u'physics',
                            u'friction',
@@ -293,7 +293,7 @@ SEARCH_RESULTS = {
             {u'authors': [u'1df3bab1-1dc7-4017-9b3a-960a87e706b1',
                           u'e5a07af6-09b9-4b74-aa7a-b7510bee90b8'],
              u'bodySnippet': None,
-             u'id': u'209deb1f-1a46-4369-9e0d-18674cf58a3e',
+             u'id': u'209deb1f-1a46-4369-9e0d-18674cf58a3e@7',
              u'keywords': [u'college physics',
                            u'introduction',
                            u'physics'],
@@ -399,7 +399,7 @@ SEARCH_RESULTS = {
                  u'suffix': None,
                  u'surname': u'Physics',
                  u'title': None,
-                 u'website': None}
+                 u'website': None},
             ],
             u'types': [
                 {u'name': u'Collection',

--- a/cnxarchive/views.py
+++ b/cnxarchive/views.py
@@ -322,7 +322,7 @@ def search(environ, start_response):
     results['results'] = {'total': len(db_results), 'items': []}
     for record in db_results:
         results['results']['items'].append({
-            'id': record['id'],
+            'id': '{}@{}'.format(record['id'],record['version']),
             'mediaType': record['mediaType'],
             'title': record['title'],
             'authors': [a['id'] for a in record['authors']],


### PR DESCRIPTION
Adds the @ver to the search result ids. This is for google crawling, to avoid a redir on reach content load.
This abuses the 'id' in the view a bit: everywhere else, 'id' is pared w/ 'version' to point to a specific bit of content, but I think it's acceptable.
