### PR TITLE
Fix invalid references

### DIFF
--- a/cnxarchive/to_html.py
+++ b/cnxarchive/to_html.py
@@ -180,7 +180,7 @@ class ReferenceResolver:
 
     def __call__(self):
         messages = []
-        messages.extend(self.fix_img_references())
+        messages.extend(self.fix_media_references())
         messages.extend(self.fix_anchor_references())
         messages = [e.message for e in messages]
         return etree.tostring(self.document), messages
@@ -260,30 +260,41 @@ class ReferenceResolver:
                         or ref.startswith('javascript:')
         return should_ignore
 
-    def fix_img_references(self):
+    def fix_media_references(self):
         """Fix references to interal resources."""
         # Catch the invalid, unparsable, etc. references.
         bad_references = []
 
-        for img in self.apply_xpath('//html:img'):
-            filename = img.get('src')
-            if not filename or self._should_ignore_reference(filename):
-                continue
+        media_xpath = {
+                '//html:img': 'src',
+                '//html:audio': 'src',
+                '//html:video': 'src',
+                '//html:object': 'data',
+                '//html:object/html:embed': 'src',
+                '//html:source': 'src',
+                '//html:span': 'data-src',
+                }
 
-            try:
-                ref_type, payload = parse_reference(filename)
-                filename, module_id, version = payload
-            except ValueError:
-                exc = InvalidReference(self.document_ident, filename)
-                bad_references.append(exc)
-                continue
+        for xpath, attr in media_xpath.iteritems():
+            for elem in self.apply_xpath(xpath):
+                filename = elem.get(attr)
+                if not filename or self._should_ignore_reference(filename):
+                    continue
 
-            try:
-                info = self.get_resource_info(filename, module_id, version)
-            except ReferenceNotFound as exc:
-                bad_references.append(exc)
-            else:
-                img.set('src', '/resources/{}'.format(info['hash'],))
+                try:
+                    ref_type, payload = parse_reference(filename)
+                    filename, module_id, version = payload
+                except ValueError:
+                    exc = InvalidReference(self.document_ident, filename)
+                    bad_references.append(exc)
+                    continue
+
+                try:
+                    info = self.get_resource_info(filename, module_id, version)
+                except ReferenceNotFound as exc:
+                    bad_references.append(exc)
+                else:
+                    elem.set(attr, '/resources/{}'.format(info['hash'],))
         return bad_references
 
     def fix_anchor_references(self):


### PR DESCRIPTION
- Add more tests for to_html reference resolver
- Transform resource paths for media elements in to_html
  - //img/@src
  - //audio/@src
  - //video/@src
  - //object/@data
  - //object/embed/@src
  - //source/@src
