### PR TITLE
WIP: add support for returning module contents as HTML

### DIFF
--- a/cnxarchive/__init__.py
+++ b/cnxarchive/__init__.py
@@ -110,10 +110,10 @@ def main(global_config, **settings):
     load_logging_configuration(logging_config_filepath)
 
     app = Application()
-    app.add_route('/contents/{ident_hash}', 'cnxarchive.views:get_content')
-    app.add_route('/contents/{ident_hash}.html', 'cnxarchive.views:get_content_html')
-    app.add_route('/contents/{ident_hash}.json', 'cnxarchive.views:get_content_json')
+    app.add_route('/contents/{ident_hash:.*}.html', 'cnxarchive.views:get_content_html')
+    app.add_route('/contents/{ident_hash:.*}.json', 'cnxarchive.views:get_content_json')
     # app.add_route('/contents/{ident_hash}.snippet', 'cnxarchive.views:get_content_snippet')
+    app.add_route('/contents/{ident_hash}', 'cnxarchive.views:get_content')
     app.add_route('/resources/{hash}', 'cnxarchive.views:get_resource')
     app.add_route('/exports/{ident_hash}.{type}{ignore:(/.*)?}', 'cnxarchive.views:get_export')
     app.add_route('/extras/{ident_hash}', 'cnxarchive.views:get_extra')

--- a/cnxarchive/tests/test_views.py
+++ b/cnxarchive/tests/test_views.py
@@ -669,6 +669,40 @@ class ViewsTestCase(unittest.TestCase):
         self.assertEqual(get_content(4), 'Version 4')
         self.assertEqual(get_content(5), 'Version 5')
 
+    def test_content_collection_as_html(self):
+        uuid = 'e79ffde3-7fb4-4af3-9ec8-df648b391597'
+        version = '7.1'
+
+        # Build the request environment.
+        environ = self._make_environ()
+        routing_args = {'ident_hash': "{}@{}".format(uuid, version)}
+        environ['wsgiorg.routing_args'] = routing_args
+
+        expected = """<html xmlns="http://www.w3.org/1999/xhtml">\n  <body><ul><li><a href="/contents/e79ffde3-7fb4-4af3-9ec8-df648b391597@7.1.html">College Physics</a><ul><li><a href="/contents/209deb1f-1a46-4369-9e0d-18674cf58a3e@7.html">Preface</a></li><li><a>Introduction: The Nature of Science and Physics</a><ul><li><a href="/contents/f3c9ab70-a916-4d8c-9256-42953287b4e9@3.html">Introduction to Science and the Realm of Physics, Physical Quantities, and Units</a></li><li><a href="/contents/d395b566-5fe3-4428-bcb2-19016e3aa3ce@4.html">Physics: An Introduction</a></li><li><a href="/contents/c8bdbabc-62b1-4a5f-b291-982ab25756d7@6.html">Physical Quantities and Units</a></li><li><a href="/contents/5152cea8-829a-4aaf-bcc5-c58a416ecb66@7.html">Accuracy, Precision, and Significant Figures</a></li><li><a href="/contents/5838b105-41cd-4c3d-a957-3ac004a48af3@5.html">Approximation</a></li></ul></li><li><a>Further Applications of Newton\'s Laws: Friction, Drag, and Elasticity</a><ul><li><a href="/contents/24a2ed13-22a6-47d6-97a3-c8aa8d54ac6d@2.html">Introduction: Further Applications of Newton&#8217;s Laws</a></li><li><a href="/contents/ea271306-f7f2-46ac-b2ec-1d80ff186a59@5.html">Friction</a></li><li><a href="/contents/26346a42-84b9-48ad-9f6a-62303c16ad41@6.html">Drag Forces</a></li><li><a href="/contents/56f1c5c1-4014-450d-a477-2121e276beca@8.html">Elasticity: Stress and Strain</a></li></ul></li><li><a href="/contents/f6024d8a-1868-44c7-ab65-45419ef54881@3.html">Atomic Masses</a></li><li><a href="/contents/7250386b-14a7-41a2-b8bf-9e9ab872f0dc@2.html">Selected Radioactive Isotopes</a></li><li><a href="/contents/c0a76659-c311-405f-9a99-15c71af39325@5.html">Useful Information</a></li><li><a href="/contents/ae3e18de-638d-4738-b804-dc69cd4db3a3@5.html">Glossary of Key Symbols and Notation</a></li></ul></li></ul></body>\n</html>\n"""
+
+        # Call the view.
+        from ..views import get_content_html
+
+        # Check that the view returns the expected html
+        resp_body = get_content_html(environ, self._start_response)
+        self.assertEqual(resp_body[0], expected)
+
+    def test_content_module_as_html(self):
+        uuid = 'd395b566-5fe3-4428-bcb2-19016e3aa3ce'
+        version = '4'
+
+        # Build the request environment.
+        environ = self._make_environ()
+        routing_args = {'ident_hash': "{}@{}".format(uuid, version)}
+        environ['wsgiorg.routing_args'] = routing_args
+
+        # Call the view.
+        from ..views import get_content_html
+
+        # Check that the view returns some html
+        resp_body = get_content_html(environ, self._start_response)
+        self.assertTrue(resp_body[0].startswith('<html'))
+
     def test_resources(self):
         # Test the retrieval of resources contained in content.
         hash = '8c48c59e411d1e31cc0186be535fa5eb'

--- a/cnxarchive/views.py
+++ b/cnxarchive/views.py
@@ -10,11 +10,16 @@ import os
 import json
 import logging
 import psycopg2
+
+from lxml import etree
 from cnxquerygrammar.query_parser import grammar, DictFormater
 
 from . import get_settings
 from . import httpexceptions
-from .utils import split_ident_hash, portaltype_to_mimetype, slugify
+from .utils import (
+    portaltype_to_mimetype, MODULE_MIMETYPE, COLLECTION_MIMETYPE,
+    split_ident_hash, slugify,
+    )
 from .database import CONNECTION_SETTINGS_KEY, SQL
 from .search import (
     search as database_search, Query,
@@ -165,9 +170,31 @@ def get_export_file(cursor, id, version, type, exports_dirs):
         raise ExportError('{} not found'.format(filename))
 
 
-# ######### #
-#   Views   #
-# ######### #
+HTML_WRAPPER = """\
+<html xmlns="http://www.w3.org/1999/xhtml">
+  <body>{}</body>
+</html>
+"""
+
+
+def html_listify(tree, root_ul_element):
+    for node in tree:
+        li_elm = etree.SubElement(root_ul_element, 'li')
+        a_elm = etree.SubElement(li_elm, 'a')
+        a_elm.text = node['title']
+        if node['id'] != 'subcol':
+            # FIXME Hard coded route...
+            a_elm.set('href', '/contents/{}.html'.format(node['id']))
+        if 'contents' in node:
+            elm = etree.SubElement(li_elm, 'ul')
+            html_listify(node['contents'], elm)
+
+
+def tree_to_html(tree):
+    ul = etree.Element('ul')
+    html_listify([tree], ul)
+    return HTML_WRAPPER.format(etree.tostring(ul))
+
 
 def _get_content_json(environ, start_response):
     """Helper that return a piece of content as a dict using the ident-hash (uuid@version)."""
@@ -210,9 +237,15 @@ def _get_content_json(environ, start_response):
 
     return result
 
-def get_content_json(environ, start_response):
-    """Retrieve a piece of content as JSON using the ident-hash (uuid@version)."""
 
+# ######### #
+#   Views   #
+# ######### #
+
+def get_content_json(environ, start_response):
+    """Retrieve a piece of content as JSON using
+    the ident-hash (uuid@version).
+    """
     result = _get_content_json(environ, start_response)
 
     result = json.dumps(result)
@@ -221,20 +254,28 @@ def get_content_json(environ, start_response):
     start_response(status, headers)
     return [result]
 
-def get_content_html(environ, start_response):
-    """Retrieve a piece of content as HTML using the ident-hash (uuid@version)."""
 
+def get_content_html(environ, start_response):
+    """Retrieve a piece of content as HTML using
+    the ident-hash (uuid@version).
+    """
     result = _get_content_json(environ, start_response)
+
+    media_type = result['mediaType']
+    if media_type == MODULE_MIMETYPE:
+        content = result['content']
+    elif media_type == COLLECTION_MIMETYPE:
+        content = tree_to_html(result['tree'])
 
     status = "200 OK"
     headers = [('Content-type', 'application/xhtml+xml',)]
     start_response(status, headers)
-    return result['content']
+    return [content]
 
 
 def get_content(environ, start_response):
     """Retrieve a piece of content using the ident-hash (uuid@version).
-       Depending on the HTTP_ACCEPT header return HTML or JSON.
+    Depending on the HTTP_ACCEPT header return HTML or JSON.
     """
     if 'application/xhtml+xml' in environ.get('HTTP_ACCEPT', ''):
         return get_content_html(environ, start_response)


### PR DESCRIPTION
Makes debugging a bit easier since webview is not required (and you do not have to sift through escaped HTML in JSON)

This still needs tests and probably has bugs like:
- what to do when the content is a collection
- pattern matching fails when trying to include file extensions
