### PR TITLE
Make join_ident_hash work even if versions are integers

### DIFF
--- a/cnxarchive/tests/test_utils.py
+++ b/cnxarchive/tests/test_utils.py
@@ -165,6 +165,13 @@ class JoinIdentTestCase(unittest.TestCase):
         with self.assertRaises(AssertionError):
             self.call_target(id, version)
 
+    def test_w_integer_version(self):
+        id = '85e57f79-02b3-47d2-8eed-c1bbb1e1d5c2'
+        version = (1, 2,)
+        expected = '{}@1.2'.format(id)
+        ident_hash = self.call_target(id, version)
+        self.assertEqual(expected, ident_hash)
+
 
 class SlugifyTestCase(unittest.TestCase):
 

--- a/cnxarchive/utils.py
+++ b/cnxarchive/utils.py
@@ -65,7 +65,7 @@ def join_ident_hash(id, version):
     join_args = [id]
     if isinstance(version, (tuple, list,)):
         assert len(version) == 2, "version sequence must be two values."
-        version = VERSION_CHAR.join([x for x in version if x is not None])
+        version = VERSION_CHAR.join([str(x) for x in version if x is not None])
     if version:
         join_args.append(version)
     return HASH_CHAR.join(join_args)


### PR DESCRIPTION
Fix `TypeError: sequence item 0: expected string, int found` for this
line:

```
version = VERSION_CHAR.join([x for x in version if x is not None])
```

This fixes the failed test in Connexions/cnx-publishing#30
