### PR TITLE
Add transform module content function to be used in postgres

### DIFF
--- a/cnxarchive/sql/schema/schema.sql
+++ b/cnxarchive/sql/schema/schema.sql
@@ -375,9 +375,22 @@ AS $$
   db_connection = plpydbapi.connect()
   html_abstract, warning_messages = transform_abstract(abstract, db_connection)
   if warning_messages:
-    plpy.log(warning_messages)
+    plpy.warning(warning_messages)
   db_connection.close()
   return html_abstract
+$$ LANGUAGE plpythonu;
+
+CREATE OR REPLACE FUNCTION html_content(cnxml text)
+  RETURNS text
+AS $$
+  import plpydbapi
+  from cnxarchive.to_html import transform_module_content
+  db_connection = plpydbapi.connect()
+  html_content, warning_messages = transform_module_content(cnxml, db_connection)
+  if warning_messages:
+    plpy.warning(warning_messages)
+  db_connection.close()
+  return html_content
 $$ LANGUAGE plpythonu;
 
 CREATE TABLE modulecounts (


### PR DESCRIPTION
For example,

`SELECT html_content(encode(file, 'escape')::text) FROM files`

to get the cnxml in "file" transformed to html,
but this does not add any files to the database.

MANUAL-UPGRADE: add a function (see schema.sql) to existing db
