### PR TITLE
Search pagination

### DIFF
--- a/cnxarchive/search.py
+++ b/cnxarchive/search.py
@@ -74,6 +74,8 @@ SET_OPERATORS = ('OR', 'AND', 'NOT',)
 QUERY_TYPES = ('OR', 'AND', 'weakAND',)
 DEFAULT_QUERY_TYPE = QUERY_TYPES[-1]
 
+DEFAULT_PER_PAGE = 20
+
 
 class Query(Sequence):
     """A structured respresentation of the query string"""

--- a/cnxarchive/tests/data/search_results.json
+++ b/cnxarchive/tests/data/search_results.json
@@ -8,7 +8,9 @@
     "tag": "text", 
     "value": "college physics"
    }
-  ]
+  ],
+  "per_page": 20,
+  "page": 1
  }, 
  "results": {
   "items": [

--- a/cnxarchive/views.py
+++ b/cnxarchive/views.py
@@ -25,6 +25,7 @@ from .database import CONNECTION_SETTINGS_KEY, SQL
 from .search import (
     search as database_search, Query,
     QUERY_TYPES, DEFAULT_QUERY_TYPE,
+    DEFAULT_PER_PAGE
     )
 from .sitemap import Sitemap
 
@@ -362,6 +363,8 @@ def search(environ, start_response):
     empty_response = json.dumps({
         u'query': {
             u'limits': [],
+            u'per_page': DEFAULT_PER_PAGE,
+            u'page': 1,
             },
         u'results': {
             u'items': [],
@@ -380,6 +383,19 @@ def search(environ, start_response):
     if query_type is None or query_type not in QUERY_TYPES:
         query_type = DEFAULT_QUERY_TYPE
 
+    try:
+        per_page = int(params.get('per_page', [])[0])
+    except (TypeError, ValueError, IndexError):
+        per_page = None
+    if per_page is None or per_page <= 0:
+        per_page = DEFAULT_PER_PAGE
+    try:
+        page = int(params.get('page', [])[0])
+    except (TypeError, ValueError, IndexError):
+        page = None
+    if page is None or page <= 0:
+        page = 1
+
     query = Query.from_raw_query(search_terms)
     if not(query.filters or query.terms):
         start_response('200 OK', [('Content-type', 'application/json')])
@@ -392,9 +408,11 @@ def search(environ, start_response):
     results['query'] = {
             'limits': limits,
             'sort': query.sorts,
+            'per_page': per_page,
+            'page': page,
             }
     results['results'] = {'total': len(db_results), 'items': []}
-    for record in db_results:
+    for record in db_results[((page - 1) * per_page):(page * per_page)]:
         results['results']['items'].append({
             'id': '{}@{}'.format(record['id'],record['version']),
             'mediaType': record['mediaType'],


### PR DESCRIPTION
Add pagination to search results, default 20 results per page

For example, if you search for `q=introduction`, you'll get 5 results.
You can force pagination by searching for `q=introduction&per_page=3`.
You will get 3 result items instead of 5 and you can fetch the remaining
2 items by doing `q=introduction&per_page=3&page=2`.

Search results `query` will now contain the `per_page` value and `page`
number.  Search results will only return 20 `items` by default.
Everything else in the search results remain unchanged.
