### PR TITLE
determine recencey based on data, not clock

### DIFF
--- a/cnxarchive/sql/schema/hits-functions.sql
+++ b/cnxarchive/sql/schema/hits-functions.sql
@@ -11,7 +11,7 @@ AS $$
     now_timestamp TIMESTAMP WITH TIME ZONE;
     past_timestamp TIMESTAMP WITH TIME ZONE;
   BEGIN
-    now_timestamp := now();
+    now_timestamp := COALESCE(MAX(end_timestamp), NOW()) FROM document_hits;
     past_timestamp := now_timestamp - interval '1 week';
     RETURN past_timestamp;
   END;

--- a/cnxarchive/tests/test_database.py
+++ b/cnxarchive/tests/test_database.py
@@ -1336,12 +1336,30 @@ class DocumentHitsTestCase(unittest.TestCase):
         return hits
 
     @db_connect
-    def test_recency_function(self, cursor):
+    def test_recency_function_w_no_document_hits(self, cursor):
         # Exam the function out puts a date.
 
         # At the time of this writting the recency is one week.
         from datetime import datetime, timedelta
         then = datetime.today() - timedelta(7)
+
+        cursor.execute("SELECT get_recency_date();")
+        value = cursor.fetchone()[0]
+        # We're mostly checking by the day rather than by time,
+        #   so checking by date should be sufficient.
+        self.assertEqual(then.date(), value.date())
+
+    @db_connect
+    def test_recency_function_w_document_hits(self, cursor):
+        # Exam the function out puts a date.
+
+        self.create_hits()
+        cursor.execute('SELECT MAX(end_timestamp) FROM document_hits')
+        max_end_timestamp = cursor.fetchone()[0]
+
+        # At the time of this writting the recency is one week.
+        from datetime import datetime, timedelta
+        then = max_end_timestamp - timedelta(7)
 
         cursor.execute("SELECT get_recency_date();")
         value = cursor.fetchone()[0]


### PR DESCRIPTION
I changed the code slightly so it'll return recency based on clock if no data is available:

``` diff
-    now_timestamp := max(end_timestamp) from document_hits;
+    now_timestamp := COALESCE(MAX(end_timestamp), NOW()) FROM document_hits;
```

That fixed the test that was broken https://travis-ci.org/Connexions/cnx-archive/builds/14392216
and I added another test.
