### PR TITLE
Change search result json format to avoid iteration in webview

### DIFF
--- a/cnxarchive/tests/data/search_results.json
+++ b/cnxarchive/tests/data/search_results.json
@@ -21,7 +21,7 @@
     "title": "College Physics", 
     "mediaType": "application/vnd.org.cnx.collection",
     "authors": [
-     "e5a07af6-09b9-4b74-aa7a-b7510bee90b8"
+     {"index": 0, "id": "e5a07af6-09b9-4b74-aa7a-b7510bee90b8"}
     ], 
     "keywords": [
      "college physics", 
@@ -82,7 +82,7 @@
     "title": "Derived Copy of College Physics", 
     "mediaType": "application/vnd.org.cnx.collection",
     "authors": [
-     "e5a07af6-09b9-4b74-aa7a-b7510bee90b8"
+     {"index": 0, "id": "e5a07af6-09b9-4b74-aa7a-b7510bee90b8"}
     ], 
     "keywords": [], 
     "id": "a733d0d2-de9b-43f9-8aa9-f0895036899e@1.1"
@@ -94,8 +94,8 @@
     "title": "Preface to College Physics", 
     "mediaType": "application/vnd.org.cnx.module",
     "authors": [
-     "1df3bab1-1dc7-4017-9b3a-960a87e706b1", 
-     "e5a07af6-09b9-4b74-aa7a-b7510bee90b8"
+     {"index": 1, "id": "1df3bab1-1dc7-4017-9b3a-960a87e706b1"},
+     {"index": 0, "id": "e5a07af6-09b9-4b74-aa7a-b7510bee90b8"}
     ], 
     "keywords": [
      "college physics", 
@@ -157,11 +157,13 @@
     "values": [
      {
       "count": 3, 
-      "value": "e5a07af6-09b9-4b74-aa7a-b7510bee90b8"
+      "value": "e5a07af6-09b9-4b74-aa7a-b7510bee90b8",
+      "index": 0
      }, 
      {
       "count": 1, 
-      "value": "1df3bab1-1dc7-4017-9b3a-960a87e706b1"
+      "value": "1df3bab1-1dc7-4017-9b3a-960a87e706b1",
+      "index": 1
      }
     ]
    }, 

--- a/cnxarchive/tests/test_views.py
+++ b/cnxarchive/tests/test_views.py
@@ -925,6 +925,30 @@ class ViewsTestCase(unittest.TestCase):
         for i in results:
             self.assertEqual(results[i], SEARCH_RESULTS[i])
 
+    def test_search_filter_by_authorID(self):
+        # Build the request
+        environ = self._make_environ()
+        environ['QUERY_STRING'] = 'q="college physics" '\
+                'authorID:1df3bab1-1dc7-4017-9b3a-960a87e706b1'
+
+        from ..views import search
+        results = search(environ, self._start_response)[0]
+        status = self.captured_response['status']
+        headers = self.captured_response['headers']
+
+        self.assertEqual(status, '200 OK')
+        self.assertEqual(headers[0], ('Content-type', 'application/json'))
+        results = json.loads(results)
+        self.assertEqual(results['results']['total'], 1)
+        self.assertEqual(results['query'], {
+            u'sort': [],
+            u'per_page': 20,
+            u'page': 1,
+            u'limits': [{u'tag': u'text', u'value': u'college physics'},
+                        {u'tag': u'authorID', u'index': 1,
+                         u'value': u'1df3bab1-1dc7-4017-9b3a-960a87e706b1'}],
+            })
+
     def test_search_only_subject(self):
         # From the Content page, we have a list of subjects (tags),
         # they link to the search page like: /search?q=subject:"Arts"


### PR DESCRIPTION
In addition to author uuids in results.items and results.limits, include
index of the author in results.auxiliary.authors

@dak see the changes in cnxarchive/tests/data/search_results.json
