### PR TITLE
Always return default Access-Control-Allow-Headers whitelist

### DIFF
--- a/cnxarchive/__init__.py
+++ b/cnxarchive/__init__.py
@@ -21,6 +21,19 @@ DEFAULT_LOGGING_CONFIG_FILEPATH = os.path.join(here, 'default-logging.ini')
 logger = logging.getLogger('cnxarchive')
 _settings = None
 
+DEFAULT_ACCESS_CONTROL_ALLOW_HEADERS = [
+    'origin',
+    'dnt',
+    'accept-encoding',
+    'accept-language',
+    'keep-alive',
+    'user-agent',
+    'x-requested-with',
+    'if-modified-since',
+    'cache-control',
+    'content-type',
+    ]
+
 def get_settings():
     """Retrieve the application settings"""
     global _settings
@@ -71,9 +84,8 @@ class Application:
         def r(status, headers, *args, **kwargs):
             headers.append(('Access-Control-Allow-Origin', '*'))
             headers.append(('Access-Control-Allow-Methods', 'GET, OPTIONS'))
-            req_headers = environ.get('HTTP_ACCESS_CONTROL_REQUEST_HEADERS')
-            if req_headers:
-                headers.append(('Access-Control-Allow-Headers', req_headers))
+            headers.append(('Access-Control-Allow-Headers',
+                            ','.join(DEFAULT_ACCESS_CONTROL_ALLOW_HEADERS)))
             start_response(status, headers, *args, **kwargs)
         return r
 

--- a/cnxarchive/tests/test_application.py
+++ b/cnxarchive/tests/test_application.py
@@ -9,6 +9,8 @@ import os
 import unittest
 from wsgiref.util import setup_testing_defaults
 
+from .. import DEFAULT_ACCESS_CONTROL_ALLOW_HEADERS
+
 
 def faux_view(environ, start_response):
     args = ', '.join(["{}={}".format(k,v)
@@ -160,6 +162,8 @@ class CORSTestCase(unittest.TestCase):
             ('Content-type', 'text/plain'),
             ('Access-Control-Allow-Origin', '*'),
             ('Access-Control-Allow-Methods', 'GET, OPTIONS'),
+            ('Access-Control-Allow-Headers',
+             ','.join(DEFAULT_ACCESS_CONTROL_ALLOW_HEADERS)),
             ]))
         self.assertEqual(self.kwargs, {})
 
@@ -173,7 +177,7 @@ class CORSTestCase(unittest.TestCase):
                 'REQUEST_METHOD': 'OPTIONS',
                 'PATH_INFO': '/',
                 'HTTP_ACCESS_CONTROL_REQUEST_HEADERS':
-                'origin, accept-encoding, accept-language, cache-control'
+                'origin, accept-encoding, accept-language, something-special'
                 }
         app(environ, self.start_response)
         self.assertEqual(self.args, ('200 OK', [
@@ -181,7 +185,7 @@ class CORSTestCase(unittest.TestCase):
             ('Access-Control-Allow-Origin', '*'),
             ('Access-Control-Allow-Methods', 'GET, OPTIONS'),
             ('Access-Control-Allow-Headers',
-                'origin, accept-encoding, accept-language, cache-control'),
+             ','.join(DEFAULT_ACCESS_CONTROL_ALLOW_HEADERS)),
             ]))
         self.assertEqual(self.kwargs, {})
 


### PR DESCRIPTION
This avoids OPTIONS requests sometimes disallowed because of missing
Access-Control-Allow-Headers, probably due to cached response of
reqeuests without Access-Control-Request-Headers.
