### PR TITLE
Ignore case when checking for english stopwords. Addresses #247

### DIFF
--- a/cnxarchive/search.py
+++ b/cnxarchive/search.py
@@ -29,8 +29,8 @@ __all__ = ('search', 'Query',)
 here = os.path.abspath(os.path.dirname(__file__))
 with open(os.path.join(here, 'data', 'common-english-words.txt'), 'r') as f:
     # stopwords are all the common english words plus single characters
-    STOPWORDS = f.read().split(',') + [chr(i)
-            for i in range(ord('a'), ord('z') + 1)]
+    STOPWORDS = (f.read().split(',')
+                 + [chr(i) for i in range(ord('a'), ord('z') + 1)])
 WILDCARD_KEYWORD = 'text'
 VALID_FILTER_KEYWORDS = ('type', 'pubYear', 'authorID', 'submitterID')
 # The maximum number of keywords and authors to return in the search result
@@ -137,7 +137,8 @@ class Query(Sequence):
             node_tree = grammar.parse(query_string)
         structured_query = DictFormater().visit(node_tree)
 
-        return cls([t for t in structured_query if t[1] not in STOPWORDS])
+        return cls([t for t in structured_query
+                    if t[1].lower() not in STOPWORDS])
 
 
 class QueryRecord(Mapping):

--- a/cnxarchive/tests/test_search.py
+++ b/cnxarchive/tests/test_search.py
@@ -21,6 +21,33 @@ with open(os.path.join(TEST_DATA_DIRECTORY, 'raw-search-rows.json'), 'r') as fb:
     RAW_QUERY_RECORDS = json.load(fb)
 
 
+class QueryTestCase(unittest.TestCase):
+    """Test the non-grammar related functionality of the Query class."""
+
+    @property
+    def target_cls(self):
+        from ..search import Query
+        return Query
+
+    def call_target(self, *args, **kwargs):
+        return self.target_cls.from_raw_query(*args, **kwargs)
+
+    def test_stopword_elimination(self):
+        """Verify the removal of stopwords from the query."""
+        raw_query = "The Cat in the Hat"
+        query = self.call_target(raw_query)
+
+        expected = [('text', 'Cat'), ('text', 'Hat')]
+        self.assertEqual(expected, query.terms)
+
+    def test_w_single_letter_stopwords(self):
+        raw_query = "I am a dog"
+        query = self.call_target(raw_query)
+
+        expected = [('text', 'dog')]
+        self.assertEqual(expected, query.terms)
+
+
 class SearchModelTestCase(unittest.TestCase):
     fixture = postgresql_fixture
 


### PR DESCRIPTION
Fixes the stopword vocabulary check to ignore case. This means things like 'A' and 'The' are now eliminated from the query terms.
