### PR TITLE
Fix testing.ini not found when using cnxarchive-initialize_db

### DIFF
--- a/cnxarchive/config.py
+++ b/cnxarchive/config.py
@@ -6,6 +6,13 @@
 # See LICENCE.txt for details.
 # ###
 
+import os.path
+
 
 # Configuration keys
 CONNECTION_STRING = 'db-connection-string'
+
+# Data directory and test data location
+here = os.path.abspath(os.path.dirname(__file__))
+TEST_DATA_DIRECTORY = os.path.join(here, 'tests', 'data')
+TEST_DATA_SQL_FILE = os.path.join(TEST_DATA_DIRECTORY, 'data.sql')

--- a/cnxarchive/scripts/initializedb.py
+++ b/cnxarchive/scripts/initializedb.py
@@ -14,15 +14,14 @@ import psycopg2
 
 from .. import config
 from ..database import initdb
-from ..tests import testing
 from ..utils import parse_app_settings
 
 
 # FIXME to be removed...
-CNXUSER_DATA_SQL_FILE = os.path.join(testing.DATA_DIRECTORY,
+CNXUSER_DATA_SQL_FILE = os.path.join(config.TEST_DATA_DIRECTORY,
                                      'cnx-user.data.sql')
 EXAMPLE_DATA_FILEPATHS = (
-    testing.DATA_SQL_FILE,
+    config.TEST_DATA_SQL_FILE,
     CNXUSER_DATA_SQL_FILE,
     )
 

--- a/cnxarchive/tests/testing.py
+++ b/cnxarchive/tests/testing.py
@@ -9,7 +9,10 @@ import os
 import functools
 
 import psycopg2
+
 from ..utils import parse_app_settings
+from ..config import TEST_DATA_DIRECTORY as DATA_DIRECTORY
+from ..config import TEST_DATA_SQL_FILE as DATA_SQL_FILE
 
 
 __all__ = (
@@ -21,8 +24,6 @@ __all__ = (
 
 
 here = os.path.abspath(os.path.dirname(__file__))
-DATA_DIRECTORY = os.path.join(here, 'data')
-DATA_SQL_FILE = os.path.join(DATA_DIRECTORY, 'data.sql')
 config_uri = None
 
 


### PR DESCRIPTION
The initialize db script imports testing which tries to set up the test
environment.  If it's run outside test context, for example:

`python setup.py install`

`initialize_cnx-archive_db --with-example-data development.ini`

You'll get the following error:

IOError: [Errno 2] No such file or directory:
'/usr/local/lib/python2.7/dist-packages/cnx_archive-0.1-py2.7.egg/testing.ini'
