### PR TITLE
don't discard the incoming type extension string when redirecting to the...

### DIFF
--- a/cnxarchive/tests/test_views.py
+++ b/cnxarchive/tests/test_views.py
@@ -524,7 +524,7 @@ class ViewsTestCase(unittest.TestCase):
         except httpexceptions.HTTPFound, e:
             self.assertEqual(e.status, '302 Found')
             self.assertEqual(e.headers, [('Location',
-                '/contents/{}@5'.format(uuid))])
+                '/contents/{}@5.json'.format(uuid))])
 
     def test_legacy_id_redirect(self):
         uuid = 'ae3e18de-638d-4738-b804-dc69cd4db3a3'


### PR DESCRIPTION
... versioned url - helps avoid one class of cache error, which we've seen in the wild
