### PR TITLE
sloppy match on hash for resoruces

### DIFF
--- a/cnxarchive/sql/get-resource.sql
+++ b/cnxarchive/sql/get-resource.sql
@@ -10,4 +10,5 @@ SELECT mf.mimetype, f.file
 FROM module_files as mf
 LEFT JOIN files f on mf.fileid = f.fileid
 WHERE f.sha1 = %(hash)s
+OR f.md5 = %(hash)s
 ;


### PR DESCRIPTION
Allow resource retrieval by either sha1 or md5
