### PR TITLE
Add route GET /contents/<book-ident-hash>:<page-ident-hash>

### DIFF
--- a/cnxarchive/__init__.py
+++ b/cnxarchive/__init__.py
@@ -122,10 +122,10 @@ def main(global_config, **settings):
     load_logging_configuration(logging_config_filepath)
 
     app = Application()
-    app.add_route('/contents/{ident_hash}{ignore:(/.*)?}.html', 'cnxarchive.views:get_content_html')
-    app.add_route('/contents/{ident_hash}{ignore:(/.*)?}.json', 'cnxarchive.views:get_content_json')
+    app.add_route('/contents/{ident_hash:([^:/]*)}{separator:(:?)}{page_ident_hash:([^/]*)}{ignore:(/.*)?}.html', 'cnxarchive.views:get_content_html')
+    app.add_route('/contents/{ident_hash:([^:/]*)}{separator:(:?)}{page_ident_hash:([^/]*)}{ignore:(/.*)?}.json', 'cnxarchive.views:get_content_json')
     # app.add_route('/contents/{ident_hash}.snippet', 'cnxarchive.views:get_content_snippet')
-    app.add_route('/contents/{ident_hash}{ignore:(/.*)?}', 'cnxarchive.views:get_content')
+    app.add_route('/contents/{ident_hash:([^:/]*)}{separator:(:?)}{page_ident_hash:([^/]*)}{ignore:(/.*)?}', 'cnxarchive.views:get_content')
     app.add_route('/resources/{hash}{ignore:(/.*)?}', 'cnxarchive.views:get_resource')
     app.add_route('/exports/{ident_hash}.{type}{ignore:(/.*)?}', 'cnxarchive.views:get_export')
     app.add_route('/extras/{ident_hash}', 'cnxarchive.views:get_extra')

--- a/cnxarchive/tests/test_application.py
+++ b/cnxarchive/tests/test_application.py
@@ -144,40 +144,104 @@ class RoutingTestCase(unittest.TestCase):
             'get_content_html': (
                 ('/contents/abcd-1234.html', {
                     'ident_hash': 'abcd-1234',
+                    'page_ident_hash': '',
+                    'separator': '',
                     'ignore': '',
                     }),
                 ('/contents/abcd-1234/title.html', {
                     'ident_hash': 'abcd-1234',
+                    'page_ident_hash': '',
+                    'separator': '',
                     'ignore': '/title',
+                    }),
+                ('/contents/abcd-1234@1.2:efgh-5678@3.html', {
+                    'ident_hash': 'abcd-1234@1.2',
+                    'page_ident_hash': 'efgh-5678@3',
+                    'separator': ':',
+                    'ignore': '',
+                    }),
+                ('/contents/abcd-1234@1.2:efgh-5678@3/ignore.html', {
+                    'ident_hash': 'abcd-1234@1.2',
+                    'page_ident_hash': 'efgh-5678@3',
+                    'separator': ':',
+                    'ignore': '/ignore',
                     }),
                 ),
             'get_content_json': (
                 ('/contents/abcd-1234.json', {
                     'ident_hash': 'abcd-1234',
+                    'page_ident_hash': '',
+                    'separator': '',
                     'ignore': '',
                     }),
                 ('/contents/abcd-1234/title.json', {
                     'ident_hash': 'abcd-1234',
+                    'page_ident_hash': '',
+                    'separator': '',
                     'ignore': '/title',
                     }),
+                ('/contents/abcd-1234@1.2:efgh-5678@3.json', {
+                    'ident_hash': 'abcd-1234@1.2',
+                    'page_ident_hash': 'efgh-5678@3',
+                    'separator': ':',
+                    'ignore': '',
+                    }),
+                ('/contents/abcd-1234@1.2:efgh-5678@3/ignore.json', {
+                    'ident_hash': 'abcd-1234@1.2',
+                    'page_ident_hash': 'efgh-5678@3',
+                    'separator': ':',
+                    'ignore': '/ignore',
+                    })
                 ),
             'get_content': (
                 ('/contents/abcd-1234', {
                     'ident_hash': 'abcd-1234',
+                    'page_ident_hash': '',
+                    'separator': '',
                     'ignore': '',
                     }),
                 ('/contents/abcd-1234/', {
                     'ident_hash': 'abcd-1234',
+                    'page_ident_hash': '',
+                    'separator': '',
                     'ignore': '/',
                     }),
                 ('/contents/abcd-1234/title', {
                     'ident_hash': 'abcd-1234',
+                    'page_ident_hash': '',
+                    'separator': '',
                     'ignore': '/title',
                     }),
                 ('/contents/abcd-1234/title/', {
                     'ident_hash': 'abcd-1234',
+                    'page_ident_hash': '',
+                    'separator': '',
                     'ignore': '/title/',
                     }),
+                ('/contents/abcd-1234:efgh-5678@3/ignore', {
+                    'ident_hash': 'abcd-1234',
+                    'page_ident_hash': 'efgh-5678@3',
+                    'separator': ':',
+                    'ignore': '/ignore',
+                    }),
+                ('/contents/abcd-1234@1.2:efgh-5678', {
+                    'ident_hash': 'abcd-1234@1.2',
+                    'page_ident_hash': 'efgh-5678',
+                    'separator': ':',
+                    'ignore': '',
+                    }),
+                ('/contents/abcd-1234@1.2:efgh-5678/', {
+                    'ident_hash': 'abcd-1234@1.2',
+                    'page_ident_hash': 'efgh-5678',
+                    'separator': ':',
+                    'ignore': '/',
+                    }),
+                ('/contents/abcd-1234@1.2:efgh-5678@3/ignore', {
+                    'ident_hash': 'abcd-1234@1.2',
+                    'page_ident_hash': 'efgh-5678@3',
+                    'separator': ':',
+                    'ignore': '/ignore',
+                    })
                 ),
             'get_resource': (
                 ('/resources/abcd1234', {


### PR DESCRIPTION
Redirect to /contents/<page-ident-hash> if it's in the book, otherwise
404

Close #269 

https://trello.com/c/b9S7kZaE/973-change-module-numbering-in-collections-to-be-the-uuid-of-the-module-instead-of-the-placement-within-the-collection
