### PR TITLE
Aux author extras GitHub issue fix 194

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,4 +24,4 @@ dist/
 # Coverage #
 ############
 .coverage
-/temp.txt
+

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Development #
 ###############
+.project
 *.pyc
 *.pyo
 *.egg-info
@@ -23,3 +24,4 @@ dist/
 # Coverage #
 ############
 .coverage
+/temp.txt

--- a/.project
+++ b/.project
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>cnx-archive</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+	</buildSpec>
+	<natures>
+	</natures>
+</projectDescription>

--- a/cnxarchive/database.py
+++ b/cnxarchive/database.py
@@ -52,7 +52,8 @@ SQL = {
     'get-module-versions': _read_sql_file('get-module-versions'),
     'get-subject-list': _read_sql_file('get-subject-list'),
     'get-featured-links': _read_sql_file('get-featured-links'),
-    }
+    'get-users-by-ids':_read_sql_file('get-users-by-ids'),
+    } 
 
 
 def initdb(settings):

--- a/cnxarchive/search.py
+++ b/cnxarchive/search.py
@@ -655,3 +655,6 @@ def search(query, query_type=DEFAULT_QUERY_TYPE,
             search_results = cursor.fetchall()
     # Wrap the SQL results.
     return QueryResults(search_results, query, query_type)
+
+
+

--- a/cnxarchive/sql/get-users-by-ids.sql
+++ b/cnxarchive/sql/get-users-by-ids.sql
@@ -1,0 +1,17 @@
+-- ###
+-- ###
+SELECT row_to_json(user_row) 
+FROM   (SELECT username                           AS id, 
+               first_name                         AS firstname, 
+               last_name                          AS surname, 
+               full_name                          AS fullname, 
+               title                              AS title, 
+               (SELECT Array_agg(value) 
+                FROM   contact_infos AS ci 
+                WHERE  ci.user_id = u.id 
+                       AND TYPE = 'EmailAddress') AS emails, 
+               NULL                               AS suffix, 
+               NULL                               AS website, 
+               NULL                               AS othername 
+        FROM   users AS u 
+        WHERE  u.username = ANY ( %s )) AS user_row

--- a/cnxarchive/tests/test_search.py
+++ b/cnxarchive/tests/test_search.py
@@ -198,7 +198,6 @@ class SearchModelTestCase(unittest.TestCase):
         expected = [{u'website': None, u'surname': u'Physics', u'suffix': None, u'firstname': u'College', u'title': None, u'othername': None, u'fullname': u'OSC Physics Maintainer', u'email': u'info@openstaxcollege.org', u'id': u'1df3bab1-1dc7-4017-9b3a-960a87e706b1'}, {u'website': None, u'surname': None, u'suffix': None, u'firstname': u'OpenStax College', u'title': None, u'othername': None, u'fullname': u'OpenStax College', u'email': u'info@openstaxcollege.org', u'id': u'e5a07af6-09b9-4b74-aa7a-b7510bee90b8'}]
         self.assertEqual(authors, expected)
 
-
 class SearchTestCase(unittest.TestCase):
     fixture = testing.data_fixture
 

--- a/cnxarchive/tests/test_views.py
+++ b/cnxarchive/tests/test_views.py
@@ -1236,6 +1236,57 @@ class ViewsTestCase(unittest.TestCase):
                         {u'tag': u'authorID', u'index': 0,
                          u'value': u'cnxcap'}],
             })
+            
+    def test_author_special_case_search(self):
+        # Test the search case where an additional database query is needed to return auxiliary author info when the first query returned no results.  
+        
+        # Build the request
+        environ = self._make_environ()
+        environ['QUERY_STRING'] = 'q=subject:"LADY GAGA AND THE SOCIOLOGY OF FAME" authorID:cnxcap authorID:OpenStaxCollege'
+
+        from ..views import search
+        results = search(environ, self._start_response)[0]
+        status = self.captured_response['status']
+        headers = self.captured_response['headers']
+
+        self.assertEqual(status, '200 OK')
+        self.assertEqual(headers[0], ('Content-type', 'application/json'))
+        results = json.loads(results)
+        self.assertEqual(results['results']['total'], 0)
+
+        expected =  [
+            [
+                {
+                    u'website': None,
+                    u'surname': u'Physics',
+                    u'suffix': None,
+                    u'firstname': u'College',
+                    u'title': None,
+                    u'othername': None,
+                    u'emails': [u'info@openstaxcollege.org'],
+                    u'fullname': u'OSC Physics Maintainer',
+                    u'id': u'cnxcap'
+                }
+            ],
+            [
+                {
+                    u'website': None,
+                    u'surname': None,
+                    u'suffix': None,
+                    u'firstname': u'OpenStax College',
+                    u'title': None,
+                    u'othername': None,
+                    u'emails': [u'info@openstaxcollege.org'],
+                    u'fullname': u'OpenStax College',
+                    u'id': u'OpenStaxCollege'
+                }
+            ]
+        ]
+            
+        self.assertEqual( results['results']['auxiliary']['authors'],expected)
+
+
+
 
     def test_search_only_subject(self):
         # From the Content page, we have a list of subjects (tags),

--- a/cnxarchive/views.py
+++ b/cnxarchive/views.py
@@ -498,11 +498,15 @@ def search(environ, start_response):
     if not(query.filters or query.terms):
         start_response('200 OK', [('Content-type', 'application/json')])
         return [empty_response]
+
     db_results = cache.search(
             query, query_type,
             nocache=params.get('nocache', [''])[0].lower() == 'true')
+            
 
     authors = db_results.auxiliary['authors']
+    
+
     # create a mapping for author id to index in auxiliary authors list
     author_mapping = {}
     for i, author in enumerate(authors):
@@ -557,6 +561,24 @@ def search(environ, start_response):
     status = '200 OK'
     headers = [('Content-type', 'application/json')]
     start_response(status, headers)
+    
+    #In the case where a search is performed with an authorId as a filter, it is possible for the database to return no results even if the author exists in the database.  Therefore, the database is queried a second time for contact information associated with only the authorIds.  The author information is then used to update the results returned by the first database query. 
+    if(len(db_results)<=0):
+        authors_list =[]
+        keyword_list = query.filters + query.terms + query.sorts
+        for key in keyword_list:
+            if(key[0]=='authorID'):
+                authors_list.append(key[1])
+        if(authors_list!=[]):
+            settings = get_settings()
+            with psycopg2.connect(settings[config.CONNECTION_STRING]) as db_connection:
+                with db_connection.cursor() as cursor:
+                    arguments =(authors_list,)
+                    statement=SQL['get-users-by-ids']
+                    cursor.execute(statement,arguments)
+                    authors_db_results=cursor.fetchall()
+            results['results']['auxiliary']['authors'] = authors_db_results
+    
     return [json.dumps(results)]
 
 

--- a/development.ini
+++ b/development.ini
@@ -3,7 +3,7 @@ use = egg:cnx-archive
 db-connection-string = dbname=cnxarchive user=cnxarchive password=cnxarchive host=localhost port=5432
 # a list of memcache servers separated by whitespace
 # (memcache is disabled if no servers are given)
-memcache-servers =
+memcache-servers = localhost
 # The number of seconds until search results cache is invalid
 # (0 = cache forever)
 search-cache-expiration = 3600
@@ -19,10 +19,11 @@ exports-allowable-types =
     pdf:pdf,application/pdf,PDF,PDF file, for viewing content offline and printing.
     epub:epub,application/epub+zip,EPUB,Electronic book format file, for viewing on mobile devices.
     zip:zip,application/zip,Offline ZIP,An offline HTML copy of the content.  Also includes XML, included media files, and other support files.
-##logging-configuration-filepath = <logging.ini (must be absolute path)>
+##
+#logging-configuration-filepath = /Users/richhart/git/cnx-archive/cnxarchive/default-logging.ini
 
 # OpenStax Accounts database connection info
-accounts.fdw.db-connection-string = dbname=oscaccounts-testing host=localhost port=5432 user=accounts password=accounts
+accounts.fdw.db-connection-string = dbname=accounts host=localhost port=5432 user=accounts password=openstaxaccounts
 
 
 
@@ -33,4 +34,4 @@ accounts.fdw.db-connection-string = dbname=oscaccounts-testing host=localhost po
 [server:main]
 use = egg:waitress#main
 host = 0.0.0.0
-port = 6543
+port = 3210


### PR DESCRIPTION
In the case where a search is performed with an authorId as a filter, it is possible for the database to return no results even if the author exists in the database.  Therefore, the database is queried a second time for contact information associated with only the authorIds.  The author information is then used to update the results returned by the first database query. 