### PR TITLE
Add aux author data for empty search results

### DIFF
--- a/cnxarchive/database.py
+++ b/cnxarchive/database.py
@@ -52,6 +52,7 @@ SQL = {
     'get-module-versions': _read_sql_file('get-module-versions'),
     'get-subject-list': _read_sql_file('get-subject-list'),
     'get-featured-links': _read_sql_file('get-featured-links'),
+    'get-users-by-ids': _read_sql_file('get-users-by-ids'),
     }
 
 

--- a/cnxarchive/sql/get-users-by-ids.sql
+++ b/cnxarchive/sql/get-users-by-ids.sql
@@ -1,0 +1,17 @@
+-- ###
+-- ###
+SELECT row_to_json(user_row) 
+FROM   (SELECT username                           AS id, 
+               first_name                         AS firstname, 
+               last_name                          AS surname, 
+               full_name                          AS fullname, 
+               title                              AS title, 
+               (SELECT ARRAY_AGG(value)
+                FROM   contact_infos AS ci 
+                WHERE  ci.user_id = u.id 
+                       AND type = 'EmailAddress') AS emails, 
+               NULL                               AS suffix, 
+               NULL                               AS website, 
+               NULL                               AS othername 
+        FROM   users AS u 
+        WHERE  u.username = ANY ( %s )) AS user_row

--- a/cnxarchive/tests/test_views.py
+++ b/cnxarchive/tests/test_views.py
@@ -1236,6 +1236,54 @@ class ViewsTestCase(unittest.TestCase):
                         {u'tag': u'authorID', u'index': 0,
                          u'value': u'cnxcap'}],
             })
+    
+    def test_author_special_case_search(self):
+        # Test the search case where an additional database query is needed to return auxiliary author info when the first query returned no results.
+        
+        # Build the request
+        environ = self._make_environ()
+        environ['QUERY_STRING'] = 'q=subject:"LADY GAGA AND THE SOCIOLOGY OF FAME" authorID:cnxcap authorID:OpenStaxCollege'
+        
+        from ..views import search
+        results = search(environ, self._start_response)[0]
+        status = self.captured_response['status']
+        headers = self.captured_response['headers']
+        
+        self.assertEqual(status, '200 OK')
+        self.assertEqual(headers[0], ('Content-type', 'application/json'))
+        results = json.loads(results)
+        self.assertEqual(results['results']['total'], 0)
+        
+        expected = [
+            [
+                {
+                    u'website': None,
+                    u'surname': u'Physics',
+                    u'suffix': None,
+                    u'firstname': u'College',
+                    u'title': None,
+                    u'othername': None,
+                    u'emails': [u'info@openstaxcollege.org'],
+                    u'fullname': u'OSC Physics Maintainer',
+                    u'id': u'cnxcap'
+                }
+            ],
+            [
+                {
+                    u'website': None,
+                    u'surname': None,
+                    u'suffix': None,
+                    u'firstname': u'OpenStax College',
+                    u'title': None,
+                    u'othername': None,
+                    u'emails': [u'info@openstaxcollege.org'],
+                    u'fullname': u'OpenStax College',
+                    u'id': u'OpenStaxCollege'
+                }
+            ]
+        ]
+        
+        self.assertEqual(results['results']['auxiliary']['authors'],expected)
 
     def test_search_only_subject(self):
         # From the Content page, we have a list of subjects (tags),

--- a/cnxarchive/views.py
+++ b/cnxarchive/views.py
@@ -498,6 +498,7 @@ def search(environ, start_response):
     if not(query.filters or query.terms):
         start_response('200 OK', [('Content-type', 'application/json')])
         return [empty_response]
+
     db_results = cache.search(
             query, query_type,
             nocache=params.get('nocache', [''])[0].lower() == 'true')
@@ -557,6 +558,30 @@ def search(environ, start_response):
     status = '200 OK'
     headers = [('Content-type', 'application/json')]
     start_response(status, headers)
+
+    #In the case where a search is performed with an authorId
+    # has a filter, it is possible for the database to return 
+    #no results even if the author exists in the database.
+    #  Therefore, the database is queried a second time for 
+    #contact information associated with only the authorIds.
+    #  The author information is then used to update the 
+    #results returned by the first database query. 
+    if len(db_results) <= 0:
+        authors_list = []
+        keyword_list = query.filters
+        for key, value in keyword_list:
+            if key == 'authorID':
+                authors_list.append(value)
+        if authors_list:
+            settings = get_settings()
+            with psycopg2.connect(settings[config.CONNECTION_STRING]) as db_connection:
+                with db_connection.cursor() as cursor:
+                    arguments = (authors_list,)
+                    statement = SQL['get-users-by-ids']
+                    cursor.execute(statement,arguments)
+                    authors_db_results = cursor.fetchall()
+            results['results']['auxiliary']['authors'] = authors_db_results
+
     return [json.dumps(results)]
 
 

--- a/development.ini
+++ b/development.ini
@@ -22,7 +22,7 @@ exports-allowable-types =
 ##logging-configuration-filepath = <logging.ini (must be absolute path)>
 
 # OpenStax Accounts database connection info
-accounts.fdw.db-connection-string = dbname=oscaccounts-testing host=localhost port=5432 user=accounts password=accounts
+accounts.fdw.db-connection-string = dbname=accounts host=localhost port=5432 user=accounts password=accounts
 
 
 


### PR DESCRIPTION
In the case where a search is performed with an authorId as a filter,
it is possible for the database to return no results even if the author
exists in the database. Therefore, the database is queried a second
time for contact information associated with only the authorIds. The
author information is then used to update the results returned by the
first database query.

Fix #194