### PR TITLE
Assign module-id to transformed document (html->cnxml).

### DIFF
--- a/cnxarchive/sql/schema/schema.sql
+++ b/cnxarchive/sql/schema/schema.sql
@@ -468,7 +468,7 @@ AS $$
      with db_connection.cursor() as cursor:
           cursor.execute("SELECT convert_from(file, 'utf-8') FROM module_files AS mf NATURAL JOIN files AS f WHERE module_ident = %s AND (filename = 'index.cnxml' OR filename = 'index.html.cnxml')", (module_ident,))
           cnxml = cursor.fetchone()[0]
-     content, warning_messages = transform_module_content(cnxml, 'cnxml2html', db_connection)
+     content, warning_messages = transform_module_content(cnxml, 'cnxml2html', db_connection, module_ident)
   if warning_messages:
       plpy.warning(warning_messages)
   return content
@@ -500,7 +500,7 @@ AS $$
           cursor.execute("SELECT convert_from(file, 'utf-8') FROM module_files AS mf NATURAL JOIN files AS f WHERE module_ident = %s AND filename = 'index.cnxml.html'", (module_ident,))
           html = cursor.fetchone()[0]
 
-     content, warning_messages = transform_module_content(html, 'html2cnxml', db_connection)
+     content, warning_messages = transform_module_content(html, 'html2cnxml', db_connection, module_ident)
   if warning_messages:
       plpy.warning(warning_messages)
   return content

--- a/cnxarchive/transforms/producers.py
+++ b/cnxarchive/transforms/producers.py
@@ -291,14 +291,15 @@ def produce_transformed_file(cursor, ident, transform_type,
     return warning_messages
 
 
-def transform_module_content(content, transform_type, db_connection):
+def transform_module_content(content, transform_type, db_connection,
+                             ident=None):
     transformer, reference_resolver, _ = TRANSFORM_TYPES[transform_type]
 
     new_content = transformer(content)
 
     # Fix up content references to cnx-archive specific urls.
     new_content, bad_refs = reference_resolver(BytesIO(new_content),
-                                               db_connection)
+                                               db_connection, ident)
 
     warning_messages = None
     if bad_refs:


### PR DESCRIPTION
Fixes Connexions/rhaptos.cnxmlutils#111

Upgrades two functions. This is a trimmed version of the results coming out of Pyrseas:
```
CREATE OR REPLACE FUNCTION cnxml_content(module_ident integer) RETURNS text
    LANGUAGE plpythonu VOLATILE
    AS $_$
  import plpydbapi
  from cnxarchive.transforms import transform_module_content
  with plpydbapi.connect() as db_connection:
     with db_connection.cursor() as cursor:
          cursor.execute("SELECT convert_from(file, 'utf-8') FROM module_files AS mf NATURAL JOIN files AS f WHERE module_ident = %s AND filename = 'index.cnxml.html'", (module_ident,))
          html = cursor.fetchone()[0]

     content, warning_messages = transform_module_content(html, 'html2cnxml', db_connection)
  if warning_messages:
      plpy.warning(warning_messages)
  return content
$_$;

CREATE OR REPLACE FUNCTION html_content(module_ident integer) RETURNS text
    LANGUAGE plpythonu VOLATILE
    AS $_$
  import plpydbapi
  from cnxarchive.transforms import transform_module_content
  with plpydbapi.connect() as db_connection:
     with db_connection.cursor() as cursor:
          cursor.execute("SELECT convert_from(file, 'utf-8') FROM module_files AS mf NATURAL JOIN files AS f WHERE module_ident = %s AND (filename = 'index.cnxml' OR filename = 'index.html.cnxml')", (module_ident,))
          cnxml = cursor.fetchone()[0]
     content, warning_messages = transform_module_content(cnxml, 'cnxml2html', db_connection)
  if warning_messages:
      plpy.warning(warning_messages)
  return content
$_$;
```