### PR TITLE
return both formats for parent data until webview is updated

### DIFF
--- a/cnxarchive/sql/get-module-metadata.sql
+++ b/cnxarchive/sql/get-module-metadata.sql
@@ -47,6 +47,16 @@ FROM (SELECT
          FROM users AS u
          WHERE u.username = ANY (m.licensors)
          ) user_rows) AS licensors,
+  p.uuid AS "parentId",
+  concat_ws('.', p.major_version, p.minor_version) AS "parentVersion",
+  p.name as "parentTitle",
+  ARRAY(SELECT row_to_json(user_rows) FROM
+        (SELECT username AS id, first_name AS firstname,
+                               last_name AS surname,
+                               full_name as fullname, title, suffix
+         FROM users
+         WHERE users.username::text = ANY (m.parentauthors)
+         ) user_rows) as "parentAuthors",
   (SELECT row_to_json(parent_row)
    FROM (
      SELECT p.uuid AS id,

--- a/cnxarchive/tests/test_views.py
+++ b/cnxarchive/tests/test_views.py
@@ -67,6 +67,10 @@ COLLECTION_METADATA = {
                      },
                     ],
     u'title': u'College Physics',
+    u'parentAuthors': [],
+    u'parentId': None,
+    u'parentTitle': None,
+    u'parentVersion': '',
     u'parent': {
         'authors': [],
         'id': None,
@@ -243,6 +247,10 @@ MODULE_METADATA = {
                      },
                     ],
     u'title': u'Elasticity: Stress and Strain',
+    u'parentAuthors': [],
+    u'parentId': None,
+    u'parentTitle': None,
+    u'parentVersion': '',
     u'parent': {
         u'authors': [],
         u'id': None,


### PR DESCRIPTION
This exposes the parent data in the json for a book in formats expected by webview head of master and head of production.