### PR TITLE
Modifying app_parser, app_settings, and initdb functions

### DIFF
--- a/cnxarchive/config.py
+++ b/cnxarchive/config.py
@@ -11,6 +11,7 @@ import os.path
 
 # Configuration keys
 CONNECTION_STRING = 'db-connection-string'
+SUPER_CONN_STRING = 'super-connection-string'
 
 # Data directory and test data location
 here = os.path.abspath(os.path.dirname(__file__))

--- a/cnxarchive/scripts/hits_counter.py
+++ b/cnxarchive/scripts/hits_counter.py
@@ -73,7 +73,26 @@ def main(argv=None):
     parser.add_argument('log_file',
                         help="path to the logfile.")
     args = parser.parse_args(argv)
-
+    #############################################
+    # FIXME: args needs the attributes          #
+    # user, password, superuser, superpassword  #
+    # in order for the app_settings function to #
+    # generate a settings dictionary.  Perhaps  #
+    # the hit counter script could have its own #
+    # settings generating function similar to   #
+    # the one used by initalizedb.  Or the      #
+    # ArgumentParser could perhaps be merged    #
+    # with the app_parser in utils              #
+    # See cnxarchive.utils.app_parser,          #
+    #  cnxarchive.utils.app_settings,           #
+    # cnxarchive.scipts.initializedb.main       #
+    # for an example of how this main function  #
+    # could be refactored.                      #
+    #############################################
+    args.user = None
+    args.password = None
+    args.superuser = None
+    args.superpassword = None
     opener = LOG_FORMAT_OPENERS_MAPPING[args.log_format]
 
     # Build the URL pattern.

--- a/cnxarchive/scripts/initializedb.py
+++ b/cnxarchive/scripts/initializedb.py
@@ -12,14 +12,8 @@ import argparse
 
 import psycopg2
 
-from .. import config
 from ..database import initdb
-from ..utils import app_settings
-from ..utils import app_parser
-
-EXAMPLE_DATA_FILEPATHS = (
-    config.TEST_DATA_SQL_FILE,
-    )
+from ..utils import app_settings, app_parser
 
 
 def main(argv=None):
@@ -30,13 +24,6 @@ def main(argv=None):
     settings = app_settings(args)
     initdb(settings)
 
-    if settings['with_example_data']:
-        connection_string = settings[config.CONNECTION_STRING]
-        with psycopg2.connect(connection_string) as db_connection:
-            with db_connection.cursor() as cursor:
-                for filepath in EXAMPLE_DATA_FILEPATHS:
-                    with open(filepath, 'r') as fb:
-                        cursor.execute(fb.read())
     return 0
 
 if __name__ == '__main__':


### PR DESCRIPTION
This allows for a superuser to be provided to the 'initdb' function so that the 'plpythonu' language and methods can be created without permission errors.  After which, a non-super user can be used to complete the rest of the install.   

Changes also include a new test class which makes one call to 'initdb' to be made during the unit test class setup.  Each test is cleaned up by rolling back the changes to the database with the completion of each test function. 

Fixes #304  