### PR TITLE
Adds a database table for reporting service status messages to the frontend

### DIFF
--- a/cnxarchive/database.py
+++ b/cnxarchive/database.py
@@ -56,6 +56,7 @@ SQL = {
     'get-subject-list': _read_sql_file('get-subject-list'),
     'get-featured-links': _read_sql_file('get-featured-links'),
     'get-users-by-ids': _read_sql_file('get-users-by-ids'),
+    'get-service-state-messages': _read_sql_file('get-service-state-messages'),
     }
 
 

--- a/cnxarchive/sql/get-service-state-messages.sql
+++ b/cnxarchive/sql/get-service-state-messages.sql
@@ -1,0 +1,22 @@
+-- ###
+-- Copyright (c) 2013, Rice University
+-- This software is subject to the provisions of the GNU Affero General
+-- Public License version 3 (AGPLv3).
+-- See LICENCE.txt for details.
+-- ###
+
+-- arguments:
+
+SELECT row_to_json(combined_rows) AS module
+FROM (
+SELECT
+  name,
+  COALESCE(priority, default_priority) AS priority,
+  COALESCE(message, default_message) AS message,
+  iso8601("start") AS "start",
+  iso8601("end") AS "end"
+FROM service_state_messages NATURAL LEFT JOIN service_states
+WHERE
+  "end" > now()
+ORDER BY 2 ASC, 4 DESC
+) combined_rows ;

--- a/cnxarchive/sql/schema/constant-service-states.sql
+++ b/cnxarchive/sql/schema/constant-service-states.sql
@@ -1,0 +1,14 @@
+-- ###
+-- Copyright (c) 2015, Rice University
+-- This software is subject to the provisions of the GNU Affero General
+-- Public License version 3 (AGPLv3).
+-- See LICENCE.txt for details.
+-- ###
+
+INSERT INTO service_states (id, name, default_priority, default_message)
+VALUES (1, 'Maintenance', 1,
+        'This site is scheduled to be down for maintaince, please excuse the interuption. Thank you.');
+INSERT INTO service_states (id, name, default_priority, default_message)
+VALUES (2, 'Notice', 5,
+        'We are currently experiencing a high number of site wide errors. Please be patient while we look into the issue. Thank you.');
+SELECT pg_catalog.setval('service_states_id_seq', 2, false);

--- a/cnxarchive/sql/schema/schema.sql
+++ b/cnxarchive/sql/schema/schema.sql
@@ -644,6 +644,24 @@ CREATE TABLE users (
   is_moderated BOOLEAN
   );
 
+CREATE TABLE service_states (
+  id SERIAL PRIMARY KEY,
+  name TEXT NOT NULL,
+  default_priority INTEGER NOT NULL,
+  default_message TEXT NOT NULL
+);
+
+CREATE TABLE service_state_messages (
+  id SERIAL PRIMARY KEY,
+  service_state_id INTEGER,
+  "start" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "end" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT CURRENT_TIMESTAMP + INTERVAL '2 hours',
+  -- If present, these should take priority over the service_states values.
+  priority INTEGER DEFAULT NULL,
+  message TEXT DEFAULT NULL,
+  FOREIGN KEY (service_state_id) REFERENCES service_states (id)
+);
+
 -- =============== --
 --   Legacy only   --
 -- =============== --

--- a/cnxarchive/views.py
+++ b/cnxarchive/views.py
@@ -635,6 +635,13 @@ def _get_featured_links(cursor):
     cursor.execute(SQL['get-featured-links'])
     return [i[0] for i in cursor.fetchall()]
 
+
+def _get_service_state_messages(cursor):
+    """Returns a list of service messages."""
+    cursor.execute(SQL['get-service-state-messages'])
+    return [i[0] for i in cursor.fetchall()]
+
+
 def extras(environ, start_response):
     """Return a dict with archive metadata for webview
     """
@@ -642,9 +649,10 @@ def extras(environ, start_response):
     with psycopg2.connect(settings[config.CONNECTION_STRING]) as db_connection:
         with db_connection.cursor() as cursor:
             metadata = {
-                    'subjects': list(_get_subject_list(cursor)),
-                    'featuredLinks': _get_featured_links(cursor),
-                       }
+                'subjects': list(_get_subject_list(cursor)),
+                'featuredLinks': _get_featured_links(cursor),
+                'messages': _get_service_state_messages(cursor),
+                }
 
     status = '200 OK'
     headers = [('Content-type', 'application/json')]


### PR DESCRIPTION
The schema change and the added constants are required database changes.

I made some assumptions about displaying the messages. Basically, the messages that have a priority >= 3 will be shown 4 hours before they become active. Others are shown 2 hours before they become active.