### PR TITLE
Add compression to memcached values if > 1MB

### DIFF
--- a/cnxarchive/cache.py
+++ b/cnxarchive/cache.py
@@ -65,7 +65,8 @@ def search(query, query_type, nocache=False):
             cache_length = int(settings['search-long-cache-expiration'])
 
         # store in memcache
-        mc.set(mc_search_key, search_results, time=cache_length)
+        mc.set(mc_search_key, search_results, time=cache_length,
+               min_compress_len=1024*1024)  # compress when > 1MB
 
     # return search results
     return search_results


### PR DESCRIPTION
Fixes #312

This also adds the 'memcache-max-value-length' settings key,
which will take a bytes value and apply that as the memcache
max value length rather than the default.