### PR TITLE
Use dbapi positional arguments for the tree query.

### DIFF
--- a/cnxarchive/database.py
+++ b/cnxarchive/database.py
@@ -108,7 +108,7 @@ def get_tree(ident_hash, cursor):
     """
     uuid, version = split_ident_hash(ident_hash)
     cursor.execute(SQL['get-tree-by-uuid-n-version'],
-                   dict(id=uuid, version=version))
+                   (uuid, version,))
     try:
         tree = cursor.fetchone()[0]
     except TypeError:  # NoneType

--- a/cnxarchive/database.py
+++ b/cnxarchive/database.py
@@ -113,7 +113,11 @@ def get_tree(ident_hash, cursor):
         tree = cursor.fetchone()[0]
     except TypeError:  # NoneType
         raise ContentNotFound()
-    return tree
+    if type(tree) in (type(''),type(u'')):
+        import json
+        return json.loads(tree)
+    else:
+        return tree
 
 
 def get_module_uuid(db_connection, moduleid):

--- a/cnxarchive/sql/get-tree-by-uuid-n-version.sql
+++ b/cnxarchive/sql/get-tree-by-uuid-n-version.sql
@@ -5,5 +5,5 @@
 -- See LICENCE.txt for details.
 -- ###
 
--- arguments: id:string; version:string
-SELECT tree_to_json(%(id)s, %(version)s)::json;
+-- arguments[positional]: id:string; version:string;
+SELECT tree_to_json(%s, %s)::json;

--- a/cnxarchive/views.py
+++ b/cnxarchive/views.py
@@ -21,7 +21,7 @@ from . import config
 from . import cache
 # FIXME double import
 from . import database
-from .database import SQL
+from .database import SQL, get_tree
 from .search import (
     DEFAULT_PER_PAGE, QUERY_TYPES, DEFAULT_QUERY_TYPE,
     Query,
@@ -260,10 +260,7 @@ def _get_content_json(environ=None, ident_hash=None, reqtype=None):
             result = get_content_metadata(id, version, cursor)
             if result['mediaType'] == COLLECTION_MIMETYPE:
                 # Grab the collection tree.
-                query = SQL['get-tree-by-uuid-n-version']
-                args = dict(id=result['id'], version=result['version'])
-                cursor.execute(query, args)
-                result['tree'] = cursor.fetchone()[0]
+                result['tree'] = get_tree(ident_hash, cursor)
 
                 page_ident_hash = routing_args.get('page_ident_hash')
                 if page_ident_hash:


### PR DESCRIPTION
This change is necessary because plpydbapi does not implement
a way to translate mappings to plpy planned sql arguments.