### PR TITLE
Pin mock==1.0.1 for tests in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ tests_require = [
 description = "An archive for Connexions documents."
 
 if not IS_PY3:
-    tests_require.append('mock')
+    tests_require.append('mock==1.0.1')
 
 setup(
     name='cnx-archive',


### PR DESCRIPTION
mock >= 1.1.0 requires setuptools >= 17.1, which is too new for some
set up.

(The requirement was added in 1.1.3, but 1.1.0 is the first version that
stopped working)