### PR TITLE
Name searching match

### DIFF
--- a/cnxarchive/sql/search/author.part.sql
+++ b/cnxarchive/sql/search/author.part.sql
@@ -9,7 +9,7 @@ SELECT
   %({0})s::text||'-::-author' as key
 FROM
   latest_modules AS m,
-  users AS u 
+  users AS u
 WHERE
   u.username = ANY (m.authors)
   AND
@@ -17,7 +17,7 @@ WHERE
    OR
    u.last_name ~* req(%({0})s::text)
    OR
-   u.full_name ~* req(%({0})s::text)
+   u.full_name ~* regexp_replace(req(%({0})s::text), ' ', '.+', 'g')
    OR
    u.username ~* req(%({0})s::text)
    )

--- a/cnxarchive/tests/test_search.py
+++ b/cnxarchive/tests/test_search.py
@@ -291,7 +291,7 @@ class SearchTestCase(unittest.TestCase):
             'username': 'jmiller',
             'first_name': 'Jill',
             'last_name': 'Miller',
-            'full_name': 'Jill M.',
+            'full_name': 'Jill S. Miller',
             'title': None,
             }
 
@@ -310,7 +310,9 @@ INSERT INTO users
     def test_author_search(self, cursor):
         # Test the results of an author search.
         user_info = self._add_dummy_user()
-        query_params = [('author', user_info['first_name'])]
+        # we want to make sure an author can be searched by first and last name
+        # even if they have a middle initial
+        query_params = [('author', 'Jill Miller')]
 
 
         # Update two modules in include this user as an author.


### PR DESCRIPTION
Increased author search test case to include the specific issue, unable to match on partial author searches, or authors with middle names. Added space replacements in the query.