### PR TITLE
return 404 "not found" for the final-slash-with-no-id case as well

### DIFF
--- a/cnxarchive/tests/test_utils.py
+++ b/cnxarchive/tests/test_utils.py
@@ -101,7 +101,8 @@ class SplitIdentTestCase(unittest.TestCase):
         # Case of supplying the utility function with an empty indent-hash.
         ident_hash = ''
 
-        with self.assertRaises(ValueError):
+        from ..utils import IdentHashSyntaxError
+        with self.assertRaises(IdentHashSyntaxError):
             self.call_target(ident_hash)
 
     def test_complete_data(self):

--- a/cnxarchive/utils.py
+++ b/cnxarchive/utils.py
@@ -41,10 +41,11 @@ def split_ident_hash(ident_hash, split_version=False):
     if HASH_CHAR not in ident_hash:
         ident_hash = '{}@'.format(ident_hash)
     split_value = ident_hash.split(HASH_CHAR)
-    if split_value[0] == '':
-        raise ValueError("Missing values")
 
     try:
+        if split_value[0] == '':
+            raise ValueError("Missing values")
+
         id, version = split_value
     except ValueError:
         raise IdentHashSyntaxError(ident_hash)


### PR DESCRIPTION
JP noticed that http://archive.cnx.org/content and http://archive.cnx.org/content/ behaved differently. Fix the later to be like the former.