### PR TITLE
Use pyramid route_path instead of hardcoded paths

### DIFF
--- a/cnxarchive/tests/data/sitemap.xml
+++ b/cnxarchive/tests/data/sitemap.xml
@@ -1,71 +1,71 @@
 <?xml version="1.0" encoding="utf-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
-  <loc>http://cnx.org/contents/ae3e18de-638d-4738-b804-dc69cd4db3a3@5/glossary-of-key-symbols-and-notation</loc>
+  <loc>http://cnx.org/contents/ae3e18de-638d-4738-b804-dc69cd4db3a3%405/glossary-of-key-symbols-and-notation</loc>
   <lastmod>2013-08-31</lastmod>
   </url>
   <url>
-  <loc>http://cnx.org/contents/e79ffde3-7fb4-4af3-9ec8-df648b391597@7.1/college-physics</loc>
+  <loc>http://cnx.org/contents/e79ffde3-7fb4-4af3-9ec8-df648b391597%407.1/college-physics</loc>
   <lastmod>2013-08-31</lastmod>
   </url>
   <url>
-  <loc>http://cnx.org/contents/a733d0d2-de9b-43f9-8aa9-f0895036899e@1.1/derived-copy-of-college-physics</loc>
+  <loc>http://cnx.org/contents/a733d0d2-de9b-43f9-8aa9-f0895036899e%401.1/derived-copy-of-college-physics</loc>
   <lastmod>2013-08-31</lastmod>
   </url>
   <url>
-  <loc>http://cnx.org/contents/c0a76659-c311-405f-9a99-15c71af39325@5/useful-inf-rmation</loc>
+  <loc>http://cnx.org/contents/c0a76659-c311-405f-9a99-15c71af39325%405/useful-inf-rmation</loc>
   <lastmod>2013-07-31</lastmod>
   </url>
   <url>
-  <loc>http://cnx.org/contents/7250386b-14a7-41a2-b8bf-9e9ab872f0dc@2/selected-radioactive-isotopes</loc>
+  <loc>http://cnx.org/contents/7250386b-14a7-41a2-b8bf-9e9ab872f0dc%402/selected-radioactive-isotopes</loc>
   <lastmod>2013-07-31</lastmod>
   </url>
   <url>
-  <loc>http://cnx.org/contents/f6024d8a-1868-44c7-ab65-45419ef54881@3/atomic-masses</loc>
+  <loc>http://cnx.org/contents/f6024d8a-1868-44c7-ab65-45419ef54881%403/atomic-masses</loc>
   <lastmod>2013-07-31</lastmod>
   </url>
   <url>
-  <loc>http://cnx.org/contents/56f1c5c1-4014-450d-a477-2121e276beca@8/elasticity-stress-and-strain</loc>
+  <loc>http://cnx.org/contents/56f1c5c1-4014-450d-a477-2121e276beca%408/elasticity-stress-and-strain</loc>
   <lastmod>2013-07-31</lastmod>
   </url>
   <url>
-  <loc>http://cnx.org/contents/26346a42-84b9-48ad-9f6a-62303c16ad41@6/drag-forces</loc>
+  <loc>http://cnx.org/contents/26346a42-84b9-48ad-9f6a-62303c16ad41%406/drag-forces</loc>
   <lastmod>2013-07-31</lastmod>
   </url>
   <url>
-  <loc>http://cnx.org/contents/ea271306-f7f2-46ac-b2ec-1d80ff186a59@5/friction</loc>
+  <loc>http://cnx.org/contents/ea271306-f7f2-46ac-b2ec-1d80ff186a59%405/friction</loc>
   <lastmod>2013-07-31</lastmod>
   </url>
   <url>
-  <loc>http://cnx.org/contents/24a2ed13-22a6-47d6-97a3-c8aa8d54ac6d@2/introduction-further-applications-of-newton-s-laws</loc>
+  <loc>http://cnx.org/contents/24a2ed13-22a6-47d6-97a3-c8aa8d54ac6d%402/introduction-further-applications-of-newton-s-laws</loc>
   <lastmod>2013-07-31</lastmod>
   </url>
   <url>
-  <loc>http://cnx.org/contents/5838b105-41cd-4c3d-a957-3ac004a48af3@5/approximation</loc>
+  <loc>http://cnx.org/contents/5838b105-41cd-4c3d-a957-3ac004a48af3%405/approximation</loc>
   <lastmod>2013-07-31</lastmod>
   </url>
   <url>
-  <loc>http://cnx.org/contents/5152cea8-829a-4aaf-bcc5-c58a416ecb66@7/accuracy-precision-and-significant-figures</loc>
+  <loc>http://cnx.org/contents/5152cea8-829a-4aaf-bcc5-c58a416ecb66%407/accuracy-precision-and-significant-figures</loc>
   <lastmod>2013-07-31</lastmod>
   </url>
   <url>
-  <loc>http://cnx.org/contents/c8bdbabc-62b1-4a5f-b291-982ab25756d7@6/physical-quantities-and-units</loc>
+  <loc>http://cnx.org/contents/c8bdbabc-62b1-4a5f-b291-982ab25756d7%406/physical-quantities-and-units</loc>
   <lastmod>2013-07-31</lastmod>
   </url>
   <url>
-  <loc>http://cnx.org/contents/d395b566-5fe3-4428-bcb2-19016e3aa3ce@4/physics-an-introduction</loc>
+  <loc>http://cnx.org/contents/d395b566-5fe3-4428-bcb2-19016e3aa3ce%404/physics-an-introduction</loc>
   <lastmod>2013-07-31</lastmod>
   </url>
   <url>
-  <loc>http://cnx.org/contents/f3c9ab70-a916-4d8c-9256-42953287b4e9@3/introduction-to-science-and-the-realm-of-physics-physical-quantities-and-units</loc>
+  <loc>http://cnx.org/contents/f3c9ab70-a916-4d8c-9256-42953287b4e9%403/introduction-to-science-and-the-realm-of-physics-physical-quantities-and-units</loc>
   <lastmod>2013-07-31</lastmod>
   </url>
   <url>
-  <loc>http://cnx.org/contents/209deb1f-1a46-4369-9e0d-18674cf58a3e@7/preface-to-college-physics</loc>
+  <loc>http://cnx.org/contents/209deb1f-1a46-4369-9e0d-18674cf58a3e%407/preface-to-college-physics</loc>
   <lastmod>2013-07-31</lastmod>
   </url>
   <url>
-  <loc>http://cnx.org/contents/91cb5f28-2b8a-4324-9373-dac1d617bc24@1/indk-b</loc>
+  <loc>http://cnx.org/contents/91cb5f28-2b8a-4324-9373-dac1d617bc24%401/indk-b</loc>
   <lastmod>2011-10-05</lastmod>
   </url>
 </urlset>


### PR DESCRIPTION
- Implement a route pregenerator that allows incomplete route args

  The default route generator throws a KeyError if any variable in the
  path pattern is not defined.

  The pregenerator makes sure we can generate a path using
  request.route_path even if we don't have all the variables.

  For example, instead of having to do this:
      `request.route_path('resource', hash=hash, ignore='')`
  it's possible to do this:
      `request.route_path('resource', hash=hash)`

- Change all hardcoded paths to use request.route_path