### PR TITLE
use one strange trick to fix old modules with funny numbers

### DIFF
--- a/cnxarchive/database.py
+++ b/cnxarchive/database.py
@@ -306,8 +306,9 @@ def set_version(portal_type, legacy_version, td):
 
     elif portal_type == 'Module':
         # For modules, major should be set and minor should be None
+        # N.B. a very few older modules had major=2 and minor zero-based. Add one for those
         modified = 'MODIFY'
-        td['new']['major_version'] = int(legacy_minor)
+        td['new']['major_version'] = int(legacy_minor)+(int(legacy_major)-1)
         td['new']['minor_version'] = None
 
     return modified


### PR DESCRIPTION
A very few (but important!) modules where numbered with an alternative numbering scheme, major number 2, minor numbers starting at 0. This fix converts them to be consistent with all the others.