### PR TITLE
Update travis to use virtualenv python

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ language: python
 python:
   - "2.7"
 addons:
-  postgresql: "9.3"
+  postgresql: "9.4"
 services:
   - memcached
 before_install:
@@ -13,9 +13,9 @@ before_install:
   # using
   - sudo apt-get remove python-zope.interface
   # Install the 'plpython' extension language
-  - sudo apt-get install postgresql-plpython-9.3
+  - sudo apt-get install postgresql-plpython-9.4
   # Install the 'plxslt' extension language
-  - sudo apt-get install libxml2-dev libxslt-dev postgresql-server-dev-9.3
+  - sudo apt-get install libxml2-dev libxslt-dev postgresql-server-dev-9.4
   - git clone https://github.com/petere/plxslt.git
   - cd plxslt && sudo make && sudo make install && cd ..
   # Install cnx-query-grammar

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,23 +20,21 @@ before_install:
   - cd plxslt && sudo make && sudo make install && cd ..
   # Install cnx-query-grammar
   - git clone https://github.com/Connexions/cnx-query-grammar.git
-  - cd cnx-query-grammar && sudo /usr/bin/python setup.py install && cd ..
+  - cd cnx-query-grammar && python setup.py install && cd ..
   # Install cnx-epub
   - git clone https://github.com/Connexions/cnx-epub.git
-  - cd cnx-epub && sudo /usr/bin/python setup.py install && cd ..
+  - cd cnx-epub && python setup.py install && cd ..
   # Install rhaptos.cnxmlutils
   - git clone https://github.com/Connexions/rhaptos.cnxmlutils.git
-  - cd rhaptos.cnxmlutils && sudo /usr/bin/python setup.py install && cd ..
+  - cd rhaptos.cnxmlutils && python setup.py install && cd ..
   # Install bug-fixes branch of plpydbapi
   - git clone -b bug-fixes https://github.com/Connexions/plpydbapi.git
-  - cd plpydbapi && sudo /usr/bin/python setup.py install && cd ..
-  # Install the coverage utility and coveralls reporting utility
-  - sudo apt-get install python-pip
+  - cd plpydbapi && python setup.py install && cd ..
   # Scripts get installed to /usr/local/bin
-  - sudo /usr/bin/pip install coverage
-  - sudo /usr/bin/pip install coveralls
+  - pip install coverage
+  - pip install coveralls
 install:
-  - sudo /usr/bin/python setup.py install
+  - python setup.py install
 before_script:
   # Set up postgres roles
   - sudo -u postgres psql -d postgres -c "CREATE USER cnxarchive WITH SUPERUSER PASSWORD 'cnxarchive';"
@@ -46,11 +44,21 @@ before_script:
   - pep8 --exclude=tests *.py cnxarchive/
   - pep8 --max-line-length=200 cnxarchive/tests
 
+  # Steps to use virtualenv in postgres
+  # https://gist.github.com/mwharrison/384e8e64a6454b0e67ec
+  - git clone https://github.com/reedstrm/session_exec
+  - cd session_exec
+  - make USE_PGXS=1 -e
+  - sudo make USE_PGXS=1 -e install
+  - cd ..
+  - sudo -u postgres psql -d postgres -c "ALTER DATABASE \"cnxarchive-testing\" SET session_preload_libraries = 'session_exec';"
+  - sudo -u postgres psql -d postgres -c "ALTER DATABASE \"cnxarchive-testing\" SET session_exec.login_name = 'activate_venv';"
+
 script:
   # This is the same as `python -m unittest discover` with a coverage wrapper.
-  - sudo /usr/local/bin/coverage run --source=cnxarchive setup.py test
+  - coverage run --source=cnxarchive setup.py test
 after_success:
   # Report test coverage to coveralls.io
-  - /usr/local/bin/coveralls
+  - coveralls
 notifications:
   email: false


### PR DESCRIPTION
  - Update postgres from 9.3 to 9.4 in .travis.yml
    
    Only postgresql 9.4+ supports session_preload_libraries which is used
    in session_exec (in our case, for loading python virtualenv).

  - ~~Fix os.environ['PATH'] KeyError in activate_venv~~ (already fixed in master)
    
    ```
    Traceback (most recent call last):
      File "/home/travis/build/Connexions/cnx-archive/cnxarchive/tests/testing.py", li
        with connect() as db_connection:
      File "/home/travis/build/Connexions/cnx-archive/cnxarchive/tests/testing.py", li
        return psycopg2.connect(connection_string)
      File "/home/travis/virtualenv/python2.7.9/lib/python2.7/site-packages/psycopg2-2
        conn = _connect(dsn, connection_factory=connection_factory, async=async)
    OperationalError: FATAL:  unhandled exception in login function "venv.activate_ven
    DETAIL:  KeyError: 'PATH'
    CONTEXT:  Traceback (most recent call last):
      PL/Python function "activate_venv", line 5, in <module>
        old_os_path = os.environ['PATH']
      PL/Python function "activate_venv", line 22, in __getitem__
    PL/Python function "activate_venv"
    session_exec: perform login function "venv.activate_venv"
    ```

  - Change travis to use virtualenv python