### PR TITLE
allow initdb to work on < 9.4

### DIFF
--- a/cnxarchive/database.py
+++ b/cnxarchive/database.py
@@ -155,7 +155,7 @@ def initdb(settings):
                                                "to set "
                                                "'local_preload_libraries "
                                                "= session_exec' in "
-                                               "postgresql.conf and restart db")
+                                               "postgresql.conf and restart")
                             else:
                                 raise
 


### PR DESCRIPTION
trap attempt to set session_preload - warn about global config