### PR TITLE
Refactor routes

### DIFF
--- a/cnxarchive/database.py
+++ b/cnxarchive/database.py
@@ -17,7 +17,7 @@ from .transforms import (
     produce_cnxml_for_module, produce_html_for_module,
     transform_abstract_to_cnxml, transform_abstract_to_html,
     )
-from .utils import split_ident_hash
+from .utils import split_ident_hash, IdentHashMissingVersion
 
 here = os.path.abspath(os.path.dirname(__file__))
 SQL_DIRECTORY = os.path.join(here, 'sql')
@@ -191,8 +191,11 @@ $_$""".format(activate_path=activate_path)
 
 def get_module_ident_from_ident_hash(ident_hash, cursor):
     """Return the moduleid for a given ``ident_hash``."""
-    uuid, (mj_ver, mn_ver) = split_ident_hash(
-        ident_hash, split_version=True)
+    try:
+        uuid, (mj_ver, mn_ver) = split_ident_hash(
+            ident_hash, split_version=True)
+    except IdentHashMissingVersion as e:
+        uuid, mj_ver, mn_ver = e.id, None, None
     args = [uuid]
     stmt = "SELECT module_ident FROM {} WHERE uuid = %s"
     table_name = 'modules'

--- a/cnxarchive/scripts/hits_counter.py
+++ b/cnxarchive/scripts/hits_counter.py
@@ -96,19 +96,15 @@ def main(argv=None):
     with psycopg2.connect(connection_string) as db_connection:
         with db_connection.cursor() as cursor:
             for ident_hash, hit_count in hits.items():
-                id, version, id_type = split_ident_hash(
-                    ident_hash, return_type=True)
-                if id_type == CNXHash.FULLUUID:
-                    cursor.execute(SQL_GET_MODULE_IDENT_BY_UUID_N_VERSION,
-                                   (id, version))
-                    module_ident = cursor.fetchone()
-                    payload = (module_ident, start_timestamp, end_timestamp,
-                               hit_count,)
-                    cursor.execute("INSERT INTO document_hits "
-                                   "  VALUES (%s, %s, %s, %s);",
-                                   payload)
-                else:
-                    raise NotImplemented
+                id, version = split_ident_hash(ident_hash)
+                cursor.execute(SQL_GET_MODULE_IDENT_BY_UUID_N_VERSION,
+                               (id, version))
+                module_ident = cursor.fetchone()
+                payload = (module_ident, start_timestamp, end_timestamp,
+                           hit_count,)
+                cursor.execute("INSERT INTO document_hits "
+                               "  VALUES (%s, %s, %s, %s);",
+                               payload)
             cursor.execute("SELECT update_hit_ranks();")
     return 0
 

--- a/cnxarchive/tests/test_utils.py
+++ b/cnxarchive/tests/test_utils.py
@@ -34,11 +34,10 @@ class SplitIdentTestCase(unittest.TestCase):
             )
         ident_hash = "{}@{}".format(expected_id, expected_version)
 
-        id, version, id_type = self.call_target(ident_hash, return_type=True)
+        id, version = self.call_target(ident_hash)
 
         self.assertEqual(id, expected_id)
         self.assertEqual(version, expected_version)
-        self.assertEqual(id_type, CNXHash.FULLUUID)
 
     def test_uuid_only(self):
         # Case where the UUID has been the only value supplied in the
@@ -48,7 +47,7 @@ class SplitIdentTestCase(unittest.TestCase):
         ident_hash = "{}@".format(expected_id)
 
         with self.assertRaises(IdentHashMissingVersion) as cm:
-            self.call_target(ident_hash, return_type=True)
+            self.call_target(ident_hash)
 
         exc = cm.exception
         self.assertEqual(exc.id, expected_id)
@@ -76,12 +75,10 @@ class SplitIdentTestCase(unittest.TestCase):
         )
         ident_hash = "{}@{}".format(expected_id, '.'.join(expected_version))
 
-        id, version, id_type = self.call_target(
-            ident_hash, split_version=True, return_type=True)
+        id, version = self.call_target(ident_hash, split_version=True)
 
         self.assertEqual(id, expected_id)
         self.assertEqual(version, expected_version)
-        self.assertEqual(id_type, CNXHash.FULLUUID)
 
     def test_w_split_version_on_major_version(self):
         expected_id, expected_version = (
@@ -90,19 +87,17 @@ class SplitIdentTestCase(unittest.TestCase):
         )
         ident_hash = "{}@{}".format(expected_id, expected_version[0])
 
-        id, version, id_type = self.call_target(
-            ident_hash, split_version=True, return_type=True)
+        id, version = self.call_target(ident_hash, split_version=True)
 
         self.assertEqual(id, expected_id)
         self.assertEqual(version, expected_version)
-        self.assertEqual(id_type, CNXHash.FULLUUID)
 
     def test_w_split_version_no_version(self):
         expected_id = '85e57f79-02b3-47d2-8eed-c1bbb1e1d5c2'
         ident_hash = expected_id
 
         with self.assertRaises(IdentHashMissingVersion) as cm:
-            self.call_target(ident_hash, True, True)
+            self.call_target(ident_hash, True)
 
         exc = cm.exception
         self.assertEqual(exc.id, expected_id)

--- a/cnxarchive/tests/test_views.py
+++ b/cnxarchive/tests/test_views.py
@@ -523,26 +523,6 @@ class ViewsTestCase(unittest.TestCase):
                 },
             }])
 
-    def test_truncated_hash(self):
-        # Test for retreiving a module.
-        from ..utils import CNXHash
-        cnxhash = CNXHash('56f1c5c1-4014-450d-a477-2121e276beca')
-        version = '8'
-
-        # Build the request environment.
-        self.request.matchdict = {
-            'ident_hash': "{}@{}".format(cnxhash.get_shortid(), version)}
-        self.request.matched_route = mock.Mock()
-        self.request.matched_route.name = 'content'
-
-        # Call the view.
-        from ..views import get_content
-        with self.assertRaises(httpexceptions.HTTPFound) as cm:
-            get_content(self.request)
-        self.assertEqual(cm.exception.status, '302 Found')
-        self.assertEqual(cm.exception.headers['Location'],
-                         quote('/contents/{}@{}.json'.format(cnxhash, version)))
-
     def test_module_content(self):
         # Test for retreiving a module.
         uuid = '56f1c5c1-4014-450d-a477-2121e276beca'

--- a/cnxarchive/tests/test_views.py
+++ b/cnxarchive/tests/test_views.py
@@ -386,6 +386,8 @@ class ViewsTestCase(unittest.TestCase):
 
         # Build the request environment.
         self.request.matchdict = {'ident_hash': "{}@{}".format(uuid, version)}
+        self.request.matched_route = mock.Mock()
+        self.request.matched_route.name = 'content'
 
         # Call the view.
         from ..views import get_content
@@ -409,6 +411,8 @@ class ViewsTestCase(unittest.TestCase):
 
         # Build the request environment.
         self.request.matchdict = {'ident_hash': "{}@{}".format(uuid, version)}
+        self.request.matched_route = mock.Mock()
+        self.request.matched_route.name = 'content'
 
         # Call the view.
         from ..views import get_content
@@ -442,6 +446,8 @@ class ViewsTestCase(unittest.TestCase):
 
         # Build the request environment
         self.request.matchdict = {'ident_hash': '{}@{}'.format(uuid, version)}
+        self.request.matched_route = mock.Mock()
+        self.request.matched_route.name = 'content'
 
         # Call the view
         from ..views import get_content
@@ -495,6 +501,8 @@ class ViewsTestCase(unittest.TestCase):
 
         # Build the request environment
         self.request.matchdict = {'ident_hash': '{}@{}'.format(uuid, version)}
+        self.request.matched_route = mock.Mock()
+        self.request.matched_route.name = 'content'
 
         # Call the view
         from ..views import get_content
@@ -524,6 +532,8 @@ class ViewsTestCase(unittest.TestCase):
         # Build the request environment.
         self.request.matchdict = {
             'ident_hash': "{}@{}".format(cnxhash.get_shortid(), version)}
+        self.request.matched_route = mock.Mock()
+        self.request.matched_route.name = 'content'
 
         # Call the view.
         from ..views import get_content
@@ -540,6 +550,8 @@ class ViewsTestCase(unittest.TestCase):
 
         # Build the request environment.
         self.request.matchdict = {'ident_hash': "{}@{}".format(uuid, version)}
+        self.request.matched_route = mock.Mock()
+        self.request.matched_route.name = 'content'
 
         from ..views import get_content
 
@@ -565,6 +577,8 @@ class ViewsTestCase(unittest.TestCase):
         self.request.matchdict = {
             'ident_hash': uuid,
             }
+        self.request.matched_route = mock.Mock()
+        self.request.matched_route.name = 'content'
 
         # Call the view.
         from ..views import get_content
@@ -588,6 +602,8 @@ class ViewsTestCase(unittest.TestCase):
         self.request.matchdict = {
             'ident_hash': "{}@{}".format(short_id, version)
         }
+        self.request.matched_route = mock.Mock()
+        self.request.matched_route.name = 'content'
 
         # Call the view.
         from ..views import get_content
@@ -610,6 +626,8 @@ class ViewsTestCase(unittest.TestCase):
         self.request.matchdict = {
             'ident_hash': short_id
         }
+        self.request.matched_route = mock.Mock()
+        self.request.matched_route.name = 'content'
 
         # Call the view.
         from ..views import get_content
@@ -625,6 +643,8 @@ class ViewsTestCase(unittest.TestCase):
     def test_content_not_found(self):
         # Build the request environment
         self.request.matchdict = {'ident_hash': '98c44aed-056b-450a-81b0-61af87ee75af'}
+        self.request.matched_route = mock.Mock()
+        self.request.matched_route.name = 'content'
 
         # Call the view
         from ..views import get_content
@@ -634,6 +654,8 @@ class ViewsTestCase(unittest.TestCase):
     def test_content_not_found_w_invalid_uuid(self):
         # Build the request environment
         self.request.matchdict = {'ident_hash': 'notfound@1'}
+        self.request.matched_route = mock.Mock()
+        self.request.matched_route.name = 'content'
 
         # Call the view
         from ..views import get_content
@@ -650,7 +672,10 @@ class ViewsTestCase(unittest.TestCase):
         self.request.matchdict = {
                 'ident_hash': '{}@{}'.format(book_uuid, book_version),
                 'page_ident_hash': '{}@0'.format(page_uuid),
+                'separator': ':',
                 }
+        self.request.matched_route = mock.Mock()
+        self.request.matched_route.name = 'content'
 
         # Call the view
         from ..views import get_content
@@ -667,7 +692,10 @@ class ViewsTestCase(unittest.TestCase):
         self.request.matchdict = {
                 'ident_hash': '{}@{}'.format(book_uuid, book_version),
                 'page_ident_hash': '{}@{}'.format(page_uuid, page_version),
+                'separator': ':',
                 }
+        self.request.matched_route = mock.Mock()
+        self.request.matched_route.name = 'content'
 
         # Call the view
         from ..views import get_content
@@ -689,7 +717,10 @@ class ViewsTestCase(unittest.TestCase):
         self.request.matchdict = {
             'ident_hash': book_uuid,
             'page_ident_hash': page_uuid,
+            'separator': ':',
             }
+        self.request.matched_route = mock.Mock()
+        self.request.matched_route.name = 'content'
 
         # Call the view
         from ..views import get_content
@@ -713,7 +744,10 @@ class ViewsTestCase(unittest.TestCase):
         self.request.matchdict = {
                 'ident_hash': '{}@{}'.format(book_shortid, book_version),
                 'page_ident_hash': '{}@0'.format(page_shortid),
+                'separator': ':',
                 }
+        self.request.matched_route = mock.Mock()
+        self.request.matched_route.name = 'content'
 
         # Call the view
         from ..views import get_content
@@ -738,7 +772,10 @@ class ViewsTestCase(unittest.TestCase):
         self.request.matchdict = {
                 'ident_hash': '{}@{}'.format(book_shortid, book_version),
                 'page_ident_hash': '{}@{}'.format(page_shortid, page_version),
+                'separator': ':',
                 }
+        self.request.matched_route = mock.Mock()
+        self.request.matched_route.name = 'content'
 
         # Call the view
         from ..views import get_content
@@ -764,7 +801,10 @@ class ViewsTestCase(unittest.TestCase):
         self.request.matchdict = {
             'ident_hash': book_shortid,
             'page_ident_hash': page_shortid,
+            'separator': ':',
             }
+        self.request.matched_route = mock.Mock()
+        self.request.matched_route.name = 'content'
 
         # Call the view
         from ..views import get_content
@@ -781,6 +821,8 @@ class ViewsTestCase(unittest.TestCase):
 
         # Build the request environment.
         self.request.matchdict = {'objid': objid}
+        self.request.matched_route = mock.Mock()
+        self.request.matched_route.name = 'legacy-redirect'
 
         # Call the view.
         from ..views import redirect_legacy_content
@@ -799,6 +841,8 @@ class ViewsTestCase(unittest.TestCase):
 
         # Build the request environment.
         self.request.matchdict = {'objid': objid, 'objver': '1.5'}
+        self.request.matched_route = mock.Mock()
+        self.request.matched_route.name = 'legacy-redirect-w-version'
 
         # Call the view.
         from ..views import redirect_legacy_content
@@ -817,6 +861,8 @@ class ViewsTestCase(unittest.TestCase):
 
         # Build the request environment.
         self.request.matchdict = {'objid': objid, 'objver': '1.4'}
+        self.request.matched_route = mock.Mock()
+        self.request.matched_route.name = 'legacy-redirect-w-version'
 
         # Call the view.
         from ..views import redirect_legacy_content
@@ -834,6 +880,8 @@ class ViewsTestCase(unittest.TestCase):
 
         # Build the request environment.
         self.request.matchdict = {'objid': objid}
+        self.request.matched_route = mock.Mock()
+        self.request.matched_route.name = 'legacy-redirect'
 
         # Call the view.
         from ..views import redirect_legacy_content
@@ -853,6 +901,8 @@ class ViewsTestCase(unittest.TestCase):
         # Build the request environment.
         self.request.matchdict = {'objid': objid, 'objver': '1.4'}
         self.request.params = {'collection': '{}/latest'.format(colid)}
+        self.request.matched_route = mock.Mock()
+        self.request.matched_route.name = 'legacy-redirect-w-version'
 
         # Call the view.
         from ..views import redirect_legacy_content
@@ -873,6 +923,8 @@ class ViewsTestCase(unittest.TestCase):
         # Build the request environment.
         self.request.matchdict = {'objid': objid, 'objver': '1.4'}
         self.request.params = {'collection': 'col45555/latest'}
+        self.request.matched_route = mock.Mock()
+        self.request.matched_route.name = 'legacy-redirect-w-version'
 
         # Call the view.
         from ..views import redirect_legacy_content
@@ -896,6 +948,8 @@ class ViewsTestCase(unittest.TestCase):
         self.request.matchdict = {'objid': objid,
                                   'objver': objver,
                                   'filename': filename}
+        self.request.matched_route = mock.Mock()
+        self.request.matched_route.name = 'legacy-redirect-w-version'
 
         # Call the view.
         from ..views import redirect_legacy_content
@@ -918,6 +972,8 @@ class ViewsTestCase(unittest.TestCase):
         self.request.matchdict = {'objid': objid,
                                   'objver': objver,
                                   'filename': filename}
+        self.request.matched_route = mock.Mock()
+        self.request.matched_route.name = 'legacy-redirect-w-version'
 
         # Call the view.
         from ..views import redirect_legacy_content
@@ -953,6 +1009,8 @@ class ViewsTestCase(unittest.TestCase):
         def get_content(version):
             # Build the request environment
             self.request.matchdict = {'ident_hash': '{}@{}'.format(uuid, version)}
+            self.request.matched_route = mock.Mock()
+            self.request.matched_route.name = 'content'
 
             # Call the view
             from ..views import get_content
@@ -991,6 +1049,8 @@ class ViewsTestCase(unittest.TestCase):
         self.request.matchdict = {
             'ident_hash': '{}@{}'.format(uuid, version),
             }
+        self.request.matched_route = mock.Mock()
+        self.request.matched_route.name = 'content-html'
 
         # Call the view
         from ..views import get_content_html
@@ -1006,6 +1066,8 @@ class ViewsTestCase(unittest.TestCase):
 
         # Build the request environment.
         self.request.matchdict = {'ident_hash': "{}@{}".format(uuid, version)}
+        self.request.matched_route = mock.Mock()
+        self.request.matched_route.name = 'content-html'
 
         # Call the view.
         from ..views import get_content_html
@@ -1020,6 +1082,8 @@ class ViewsTestCase(unittest.TestCase):
 
         # Build the request.
         self.request.matchdict = {'hash': hash}
+        self.request.matched_route = mock.Mock()
+        self.request.matched_route.name = 'resource'
 
         # Call the view.
         from ..views import get_resource
@@ -1037,6 +1101,8 @@ class ViewsTestCase(unittest.TestCase):
 
         # Build the request
         self.request.matchdict = {'hash': hash}
+        self.request.matched_route = mock.Mock()
+        self.request.matched_route.name = 'resource'
 
         # Call the view
         from ..views import get_resource
@@ -1055,6 +1121,8 @@ class ViewsTestCase(unittest.TestCase):
         self.request.matchdict = {'ident_hash': ident_hash,
                                   'type': type,
                                   }
+        self.request.matched_route = mock.Mock()
+        self.request.matched_route.name = 'export'
 
         from ..views import get_export
         export = get_export(self.request).body
@@ -1093,6 +1161,8 @@ class ViewsTestCase(unittest.TestCase):
                 'ident_hash': '56f1c5c1-4014-450d-a477-2121e276beca@8',
                 'type': 'txt'
                 }
+        self.request.matched_route = mock.Mock()
+        self.request.matched_route.name = 'export'
 
         from ..views import get_export
         self.assertRaises(httpexceptions.HTTPNotFound,
@@ -1104,6 +1174,8 @@ class ViewsTestCase(unittest.TestCase):
                 'ident_hash': '24184288-14b9-11e3-86ac-207c8f4fa432@0',
                 'type': 'pdf'
                 }
+        self.request.matched_route = mock.Mock()
+        self.request.matched_route.name = 'export'
 
         from ..views import get_export
         self.assertRaises(httpexceptions.HTTPNotFound,
@@ -1114,6 +1186,8 @@ class ViewsTestCase(unittest.TestCase):
 
         # Build the request
         self.request.matchdict = {'ident_hash': id, 'type': 'pdf'}
+        self.request.matched_route = mock.Mock()
+        self.request.matched_route.name = 'export'
 
         from ..views import get_export
         with self.assertRaises(httpexceptions.HTTPFound) as cm:
@@ -1129,6 +1203,8 @@ class ViewsTestCase(unittest.TestCase):
 
         # Build the request
         self.request.matchdict = {'ident_hash': '{}@{}'.format(id, version)}
+        self.request.matched_route = mock.Mock()
+        self.request.matched_route.name = 'content-extras'
 
         from ..views import get_extra
         output = get_extra(self.request).json_body
@@ -1175,6 +1251,8 @@ class ViewsTestCase(unittest.TestCase):
 
         # Build the request
         self.request.matchdict = {'ident_hash': '{}@{}'.format(id, version)}
+        self.request.matched_route = mock.Mock()
+        self.request.matched_route.name = 'content-extras'
 
         from ..views import get_extra
         output = get_extra(self.request).json_body
@@ -1232,6 +1310,8 @@ class ViewsTestCase(unittest.TestCase):
 
         # Build the request
         self.request.matchdict = {'ident_hash': requested_ident_hash}
+        self.request.matched_route = mock.Mock()
+        self.request.matched_route.name = 'content-extras'
 
         # Call the target
         from ..views import get_extra
@@ -1277,6 +1357,8 @@ class ViewsTestCase(unittest.TestCase):
 
         # Build the request
         self.request.matchdict = {'ident_hash': '{}@{}'.format(id, version)}
+        self.request.matched_route = mock.Mock()
+        self.request.matched_route.name = 'content-extras'
 
         from ..views import get_extra
         output = get_extra(self.request).json_body
@@ -1310,6 +1392,8 @@ class ViewsTestCase(unittest.TestCase):
 
         # Build the request
         self.request.matchdict = {'ident_hash': requested_ident_hash}
+        self.request.matched_route = mock.Mock()
+        self.request.matched_route.name = 'content-extras'
 
         # Call the target
         from ..views import get_extra
@@ -1335,6 +1419,8 @@ class ViewsTestCase(unittest.TestCase):
         # Build the request
         self.request.matchdict = {
             'ident_hash': "{}@{}".format(short_id, version)}
+        self.request.matched_route = mock.Mock()
+        self.request.matched_route.name = 'content-extras'
 
         # Call the target
         from ..views import get_extra
@@ -1359,6 +1445,8 @@ class ViewsTestCase(unittest.TestCase):
 
         # Build the request
         self.request.matchdict = {'ident_hash': short_id}
+        self.request.matched_route = mock.Mock()
+        self.request.matched_route.name = 'content-extras'
 
         # Call the target
         from ..views import get_extra
@@ -1376,6 +1464,8 @@ class ViewsTestCase(unittest.TestCase):
 
         # Build the request
         self.request.matchdict = {'ident_hash': ident_hash}
+        self.request.matched_route = mock.Mock()
+        self.request.matched_route.name = 'content-extras'
 
         # Call the target
         from ..views import get_extra
@@ -1426,6 +1516,8 @@ class ViewsTestCase(unittest.TestCase):
 
         # Build the request
         self.request.matchdict = {'ident_hash': '{}@{}'.format(id, version)}
+        self.request.matched_route = mock.Mock()
+        self.request.matched_route.name = 'content-extras'
 
         from ..views import get_extra
         self.assertRaises(httpexceptions.HTTPNotFound, get_extra,
@@ -1448,6 +1540,8 @@ class ViewsTestCase(unittest.TestCase):
         # Build the request environment.
         self.request.matchdict = {'ident_hash': id}
         self.request.params = {'q': 'air or liquid drag'}
+        self.request.matched_route = mock.Mock()
+        self.request.matched_route.name = 'in-book-search'
 
         # Call the view.
         from ..views import in_book_search
@@ -1470,6 +1564,8 @@ class ViewsTestCase(unittest.TestCase):
         self.request.matchdict = {'ident_hash':
                                   '{}@{}'.format(short_id, version)}
         self.request.params = {'q': 'air or liquid drag'}
+        self.request.matched_route = mock.Mock()
+        self.request.matched_route.name = 'in-book-search'
 
         # Call the view.
         from ..views import in_book_search
@@ -1491,6 +1587,8 @@ class ViewsTestCase(unittest.TestCase):
         # Build the request environment.
         self.request.matchdict = {'ident_hash': short_id}
         self.request.params = {'q': 'air or liquid drag'}
+        self.request.matched_route = mock.Mock()
+        self.request.matched_route.name = 'in-book-search'
 
         # Call the view.
         from ..views import in_book_search
@@ -1510,6 +1608,8 @@ class ViewsTestCase(unittest.TestCase):
         self.request.matchdict = {'ident_hash': '{}@{}'.format(id, version)}
         # search query param
         self.request.params = {'q': 'air or liquid drag'}
+        self.request.matched_route = mock.Mock()
+        self.request.matched_route.name = 'in-book-search'
 
         from ..views import in_book_search
         results = in_book_search(self.request).json_body
@@ -1567,6 +1667,8 @@ class ViewsTestCase(unittest.TestCase):
         self.request.matchdict = {'ident_hash': book_uuid,
                                   'page_ident_hash': page_uuid}
         self.request.params = {'q': 'air or liquid drag'}
+        self.request.matched_route = mock.Mock()
+        self.request.matched_route.name = 'in-book-search-page'
 
         # Call the view.
         from ..views import in_book_search_highlighted_results
@@ -1590,6 +1692,8 @@ class ViewsTestCase(unittest.TestCase):
                                   'page_ident_hash': '{}@{}'.format(page_uuid, page_version)}
         # search query param
         self.request.params = {'q': 'air or liquid drag'}
+        self.request.matched_route = mock.Mock()
+        self.request.matched_route.name = 'in-book-search-page'
 
         from ..views import in_book_search_highlighted_results
         results = in_book_search_highlighted_results(self.request).json_body
@@ -1610,6 +1714,8 @@ class ViewsTestCase(unittest.TestCase):
     def test_search(self):
         # Build the request
         self.request.params = {'q': '"college physics" sort:version'}
+        self.request.matched_route = mock.Mock()
+        self.request.matched_route.name = 'search'
 
         from ..views import search
         results = search(self.request).json_body
@@ -1626,6 +1732,8 @@ class ViewsTestCase(unittest.TestCase):
     def test_search_filter_by_authorID(self):
         # Build the request
         self.request.params = {'q': '"college physics" authorID:cnxcap'}
+        self.request.matched_route = mock.Mock()
+        self.request.matched_route.name = 'search'
 
         from ..views import search
         results = search(self.request).json_body
@@ -1659,6 +1767,8 @@ class ViewsTestCase(unittest.TestCase):
         auth2 = 'authorID:DrBunsenHoneydew'
         fields = [sub, auth0, auth1, auth2]
         self.request.params = {'q': string.join(fields, ' ')}
+        self.request.matched_route = mock.Mock()
+        self.request.matched_route.name = 'search'
 
         from ..views import search
         results = search(self.request).json_body
@@ -1705,6 +1815,8 @@ class ViewsTestCase(unittest.TestCase):
 
         # Build the request
         self.request.params = {'q': 'subject:"Science and Technology"'}
+        self.request.matched_route = mock.Mock()
+        self.request.matched_route.name = 'search'
 
         from ..views import search
         results = search(self.request).json_body
@@ -1724,6 +1836,8 @@ class ViewsTestCase(unittest.TestCase):
     def test_search_with_subject(self):
         # Build the request
         self.request.params = {'q': 'title:"college physics" subject:"Science and Technology"'}
+        self.request.matched_route = mock.Mock()
+        self.request.matched_route.name = 'search'
 
         from ..views import search
         results = search(self.request).json_body
@@ -1746,6 +1860,8 @@ class ViewsTestCase(unittest.TestCase):
     def test_search_highlight_abstract(self):
         # Build the request
         self.request.params = {'q': '"college physics"'}
+        self.request.matched_route = mock.Mock()
+        self.request.matched_route.name = 'search'
 
         from ..views import search
         results = search(self.request).json_body
@@ -1810,6 +1926,9 @@ class ViewsTestCase(unittest.TestCase):
         self.assertEqual(results['results']['items'][2]['summarySnippet'], None)
 
     def test_search_no_params(self):
+        self.request.matched_route = mock.Mock()
+        self.request.matched_route.name = 'search'
+
         from ..views import search
         results = search(self.request).json_body
         status = self.request.response.status
@@ -1833,6 +1952,8 @@ class ViewsTestCase(unittest.TestCase):
 
     def test_search_whitespace(self):
         self.request.params = {'q': ' '}
+        self.request.matched_route = mock.Mock()
+        self.request.matched_route.name = 'search'
 
         from ..views import search
         results = search(self.request).body
@@ -1857,6 +1978,8 @@ class ViewsTestCase(unittest.TestCase):
 
     def test_search_utf8(self):
         self.request.params = {'q': '"你好"'}
+        self.request.matched_route = mock.Mock()
+        self.request.matched_route.name = 'search'
 
         from ..views import search
         results = search(self.request).json_body
@@ -1901,6 +2024,8 @@ class ViewsTestCase(unittest.TestCase):
 
     def test_search_punctuations(self):
         self.request.params = {'q': r":\.+'?"}
+        self.request.matched_route = mock.Mock()
+        self.request.matched_route.name = 'search'
 
         from ..views import search
         results = search(self.request).json_body
@@ -1945,6 +2070,8 @@ class ViewsTestCase(unittest.TestCase):
 
     def test_search_unbalanced_quotes(self):
         self.request.params = {'q': r'"a phrase" "something else sort:pubDate author:"first last"'}
+        self.request.matched_route = mock.Mock()
+        self.request.matched_route.name = 'search'
 
         from ..views import search
         results = search(self.request).json_body
@@ -1996,6 +2123,8 @@ class ViewsTestCase(unittest.TestCase):
 
         # Build the request
         self.request.params = {'q': 'title:"college physics" type:page'}
+        self.request.matched_route = mock.Mock()
+        self.request.matched_route.name = 'search'
 
         from ..views import search
         results = search(self.request).json_body
@@ -2035,6 +2164,8 @@ class ViewsTestCase(unittest.TestCase):
 
         # Build the request
         self.request.params = {'q': 'title:physics type:book'}
+        self.request.matched_route = mock.Mock()
+        self.request.matched_route.name = 'search'
 
         from ..views import search
         results = search(self.request).json_body
@@ -2079,6 +2210,8 @@ class ViewsTestCase(unittest.TestCase):
         # Build the request
         self.request.params = {'q': 'introduction',
                                'per_page': '3'}
+        self.request.matched_route = mock.Mock()
+        self.request.matched_route.name = 'search'
 
         def call_search_view():
             with pyramid_testing.testConfig(**config_kwargs):
@@ -2133,6 +2266,8 @@ class ViewsTestCase(unittest.TestCase):
         # Build the request
         self.request.params = {'q': 'introduction',
                                'per_page': '3'}
+        self.request.matched_route = mock.Mock()
+        self.request.matched_route.name = 'search'
 
         from ..views import search
         results = search(self.request).json_body
@@ -2228,6 +2363,8 @@ class ViewsTestCase(unittest.TestCase):
         # Build the request
         self.request.params = {'q': 'introduction',
                                'per_page': '3'}
+        self.request.matched_route = mock.Mock()
+        self.request.matched_route.name = 'search'
 
         from ..views import search
         results = search(self.request).json_body
@@ -2269,6 +2406,8 @@ class ViewsTestCase(unittest.TestCase):
         # Build the request
         self.request.params = {'q': 'introduction',
                                'per_page': '3'}
+        self.request.matched_route = mock.Mock()
+        self.request.matched_route.name = 'search'
 
         from ..views import search
         results = search(self.request).json_body
@@ -2313,6 +2452,8 @@ class ViewsTestCase(unittest.TestCase):
     def test_search_w_normal_cache(self):
         # Build the request
         self.request.params = {'q': '"college physics"'}
+        self.request.matched_route = mock.Mock()
+        self.request.matched_route.name = 'search'
 
         from ..views import search
         results = search(self.request).json_body
@@ -2343,6 +2484,8 @@ class ViewsTestCase(unittest.TestCase):
 
         # Build the request for subject search
         self.request.params = {'q': 'subject:"Science and Technology"'}
+        self.request.matched_route = mock.Mock()
+        self.request.matched_route.name = 'search'
 
         from ..views import search
         results = search(self.request).json_body
@@ -2385,6 +2528,9 @@ VALUES
    CURRENT_TIMESTAMP - INTERVAL '2 hours',
    1, 'should not show up in the results.')""")
         cursor.connection.commit()
+
+        self.request.matched_route = mock.Mock()
+        self.request.matched_route.name = 'extras'
 
         # Call the view
         from ..views import extras
@@ -2506,6 +2652,9 @@ application problems.</div>""",
         self.assertEqual(expected_messages, _remove_timestamps(messages))
 
     def test_sitemap(self):
+        self.request.matched_route = mock.Mock()
+        self.request.matched_route.name = 'sitemap'
+
         # Call the view
         from ..views import sitemap
         sitemap = sitemap(self.request).body
@@ -2514,6 +2663,9 @@ application problems.</div>""",
             self.assertMultiLineEqual(sitemap, file.read())
 
     def test_robots(self):
+        self.request.matched_route = mock.Mock()
+        self.request.matched_route.name = 'robots'
+
         # Call the view
         mocked_time = datetime.datetime(2015, 3, 4, 18, 3, 29)
         with mock.patch('cnxarchive.views.datetime') as mock_datetime:

--- a/cnxarchive/utils/ident_hash.py
+++ b/cnxarchive/utils/ident_hash.py
@@ -50,7 +50,7 @@ def split_legacy_hash(legacy_hash):
     return id, version
 
 
-def split_ident_hash(ident_hash, split_version=False, return_type=False):
+def split_ident_hash(ident_hash, split_version=False):
     """Returns a valid id and version from the <id>@<version> hash syntax."""
     if HASH_CHAR not in ident_hash:
         ident_hash = '{}@'.format(ident_hash)
@@ -78,10 +78,7 @@ def split_ident_hash(ident_hash, split_version=False, return_type=False):
         if len(split_version) == 1:
             split_version.append(None)
         version = tuple(split_version)
-    if return_type:
-        return id, version, id_type
-    else:
-        return id, version
+    return id, version
 
 
 def join_ident_hash(id, version):

--- a/cnxarchive/utils/ident_hash.py
+++ b/cnxarchive/utils/ident_hash.py
@@ -23,18 +23,22 @@ __all__ = (
     )
 
 
-class IdentHashSyntaxError(Exception):
+class IdentHashError(Exception):
+    """Base exception class for all ident hash exceptions."""
+
+
+class IdentHashSyntaxError(IdentHashError):
     """Raised when the ident-hash syntax is incorrect."""
 
 
-class IdentHashShortId(Exception):
+class IdentHashShortId(IdentHashError):
     """Raised when the ident-hash id is not a uuid"""
     def __init__(self, id, version):
         self.id = id
         self.version = version
 
 
-class IdentHashMissingVersion(Exception):
+class IdentHashMissingVersion(IdentHashError):
     """Raised when the ident-hash does not have a version"""
     def __init__(self, id):
         self.id = id

--- a/cnxarchive/views.py
+++ b/cnxarchive/views.py
@@ -138,14 +138,9 @@ def get_content_metadata(id, version, cursor):
         raise httpexceptions.HTTPNotFound()
 
 
-def is_latest(cursor, id, version):
+def is_latest(id, version):
     """Determine if this is the latest version of this content."""
-    cursor.execute(SQL['get-module-versions'], {'id': id})
-    try:
-        latest_version = cursor.fetchone()[0]
-        return latest_version == version
-    except (TypeError, IndexError,):  # None returned
-        raise httpexceptions.HTTPNotFound()
+    return get_latest_version(id) == version
 
 
 TYPE_INFO = []
@@ -532,7 +527,7 @@ def get_extra(request):
             results['downloads'] = \
                 list(get_export_allowable_types(cursor, exports_dirs,
                                                 id, version))
-            results['isLatest'] = is_latest(cursor, id, version)
+            results['isLatest'] = is_latest(id, version)
             results['canPublish'] = database.get_module_can_publish(cursor, id)
 
     resp = request.response

--- a/cnxarchive/views.py
+++ b/cnxarchive/views.py
@@ -277,7 +277,7 @@ def _get_content_json(ident_hash=None):
     settings = get_current_registry().settings
     if not ident_hash:
         ident_hash = routing_args['ident_hash']
-    id, version, id_type = split_ident_hash(ident_hash, return_type=True)
+    id, version = split_ident_hash(ident_hash)
 
     page_ident_hash = routing_args.get('page_ident_hash', '')
     if page_ident_hash:
@@ -551,8 +551,7 @@ def get_extra(request):
     settings = get_current_registry().settings
     exports_dirs = settings['exports-directories'].split()
     args = request.matchdict
-    id, version, id_type = split_ident_hash(
-        args['ident_hash'], return_type=True)
+    id, version = split_ident_hash(args['ident_hash'])
     results = {}
 
     with psycopg2.connect(settings[config.CONNECTION_STRING]) as db_connection:
@@ -608,7 +607,7 @@ def in_book_search(request):
 
     args['search_term'] = request.params.get('q', '')
 
-    id, version, id_type = split_ident_hash(ident_hash, return_type=True)
+    id, version = split_ident_hash(ident_hash)
     args['uuid'] = id
     args['version'] = version
 
@@ -664,7 +663,7 @@ def in_book_search_highlighted_results(request):
     args['search_term'] = request.params.get('q', '')
 
     # Get version from URL params
-    id, version, id_type = split_ident_hash(ident_hash, return_type=True)
+    id, version = split_ident_hash(ident_hash)
     args['uuid'] = id
     args['version'] = version
 

--- a/cnxarchive/views.py
+++ b/cnxarchive/views.py
@@ -637,7 +637,6 @@ def in_book_search(request):
                 'id': ident_hash,
                 'search_term': args['search_term'],
             }
-            len(res)
             for uuid, version, title, snippet, matches, rank in res:
                 results['results']['items'].append({
                     'rank': '{}'.format(rank),

--- a/cnxarchive/views.py
+++ b/cnxarchive/views.py
@@ -613,10 +613,7 @@ def in_book_search(request):
     args = request.matchdict
     ident_hash = args['ident_hash']
 
-    try:
-        args['search_term'] = request.params.get('q', '')
-    except (TypeError, ValueError, IndexError):
-        args['search_term'] = None
+    args['search_term'] = request.params.get('q', '')
 
     id, version, id_type = split_ident_hash(ident_hash, return_type=True)
     args['uuid'] = id
@@ -670,10 +667,7 @@ def in_book_search_highlighted_results(request):
     page_uuid, _ = split_ident_hash(page_ident_hash)
     args['page_uuid'] = page_uuid
 
-    try:
-        args['search_term'] = request.params.get('q', '')
-    except (TypeError, ValueError, IndexError):
-        args['search_term'] = None
+    args['search_term'] = request.params.get('q', '')
 
     # Get version from URL params
     id, version, id_type = split_ident_hash(ident_hash, return_type=True)
@@ -734,11 +728,7 @@ def search(request):
     resp = request.response
     resp.status = '200 OK'
     resp.content_type = 'application/json'
-    try:
-        search_terms = params.get('q', '')
-    except IndexError:
-        resp.body = empty_response
-        return resp
+    search_terms = params.get('q', '')
     query_type = params.get('t', None)
     if query_type is None or query_type not in QUERY_TYPES:
         query_type = DEFAULT_QUERY_TYPE

--- a/cnxarchive/views.py
+++ b/cnxarchive/views.py
@@ -82,12 +82,13 @@ def get_latest_version(uuid_):
 
 
 def redirect_to_canonical(cursor, id, version, id_type,
-                          route_name='content', route_args=None,
+                          route_name='', route_args=None,
                           params=None):
     """Redirect to latest version of a module / collection.
 
     Looks up path associated with the provided router.
     """
+    request = get_current_request()
     if id_type == CNXHash.SHORTID:
         full_id = get_uuid(id)
     elif id_type == CNXHash.FULLUUID:
@@ -101,6 +102,8 @@ def redirect_to_canonical(cursor, id, version, id_type,
 
     if route_args is None:
         route_args = {}
+    if not route_name:
+        route_name = request.matched_route.name
     request = get_current_request()
     route_args['ident_hash'] = join_ident_hash(full_id, version)
     if not params:
@@ -203,7 +206,7 @@ def get_export_file(cursor, id, version, type, exports_dirs):
     if not version:
         id, _, id_type = split_ident_hash(id, return_type=True)
         redirect_to_canonical(cursor, id, version, id_type,
-                              route_name='export', route_args={'type': type})
+                              route_args={'type': type})
 
     metadata = get_content_metadata(id, version, cursor)
     file_extension = type_info[type]['file_extension']
@@ -530,8 +533,7 @@ def get_extra(request):
     with psycopg2.connect(settings[config.CONNECTION_STRING]) as db_connection:
         with db_connection.cursor() as cursor:
             if not version or id_type == CNXHash.SHORTID:
-                redirect_to_canonical(cursor, id, version, id_type,
-                                      route_name='content-extras')
+                redirect_to_canonical(cursor, id, version, id_type)
             results['downloads'] = \
                 list(get_export_allowable_types(cursor, exports_dirs,
                                                 id, version))
@@ -594,7 +596,6 @@ def in_book_search(request):
         with db_connection.cursor() as cursor:
             if not version or id_type == CNXHash.SHORTID:
                 redirect_to_canonical(cursor, id, version, id_type,
-                                      route_name='in-book-search',
                                       route_args=request.matchdict,
                                       params=request.params.copy())
 
@@ -655,7 +656,6 @@ def in_book_search_highlighted_results(request):
         with db_connection.cursor() as cursor:
             if not version:
                 redirect_to_canonical(cursor, id, version, id_type,
-                                      route_name='in-book-search-page',
                                       route_args=request.matchdict,
                                       params=request.params.copy())
 


### PR DESCRIPTION
Continuation of #394

- Refactor get uuid from shortid code and get latest version code

  
- Change redirect_to_canonical to use matched route from request

  
- Get route name/args and params from request in redirect to canonical

  
- Remove duplicate test from ViewsTestCase

  test_truncate_hash is the same as test_content_shortid_version.


- Simplify is_latest helper function in views

  
- Move view helper functions to the top of the file

  
- Remove some unnecessary try-except blocks from views.py

- Remove unnecessary line "len(res)" from views in_book_search

- Replace redirect to canonical with exception views

  Instead of checking for missing versions and short ids, raise exceptions
IdentHashMissingVersion and IdentHashShortId when splitting ident hash
and redirect in exception views.

- Remove return_type from split_ident_hash

  split_ident_hash is raising IdentHashShortId for short ids, so there
is no need to return the type anymore.

- Add IdentHashError base exception class for all ident hash exceptions