### PR TITLE
Move module_files.mimetype to files.media_type

### DIFF
--- a/cnxarchive/__init__.py
+++ b/cnxarchive/__init__.py
@@ -6,6 +6,7 @@
 # See LICENCE.txt for details.
 # ###
 """Document and collection archive web application."""
+import os
 from pyramid.config import Configurator
 
 
@@ -22,6 +23,14 @@ DEFAULT_ACCESS_CONTROL_ALLOW_HEADERS = [
     'cache-control',
     'content-type',
     ]
+
+
+def find_migrations_directory():
+    """Finds and returns the location of the database migrations directory.
+    This function is used from a setuptools entry-point for db-migrator.
+    """
+    here = os.path.abspath(os.path.dirname(__file__))
+    return os.path.join(here, 'sql/migrations')
 
 
 def declare_api_routes(config):

--- a/cnxarchive/sql/get-module-metadata.sql
+++ b/cnxarchive/sql/get-module-metadata.sql
@@ -102,10 +102,10 @@ FROM (SELECT
   ARRAY(SELECT word FROM modulekeywords AS mk NATURAL JOIN keywords WHERE mk.module_ident = m.module_ident) AS keywords,
   ARRAY(
     SELECT row_to_json(module_file_row) FROM (
-      SELECT mf.filename AS filename, mf.mimetype as mimetype, f.sha1 AS id
+      SELECT mf.filename AS filename, f.media_type AS media_type, f.sha1 AS id
       FROM module_files AS mf NATURAL JOIN files AS f
       WHERE mf.module_ident = m.module_ident
-      ORDER BY f.sha1, mf.mimetype, mf.filename
+      ORDER BY f.sha1, f.media_type, mf.filename
     ) AS module_file_row) AS resources,
   m.print_style AS "printStyle"
 FROM modules m

--- a/cnxarchive/sql/get-resource.sql
+++ b/cnxarchive/sql/get-resource.sql
@@ -6,9 +6,6 @@
 -- ###
 
 -- arguments: hash:string
-SELECT mf.mimetype, f.file
-FROM module_files as mf
-LEFT JOIN files f on mf.fileid = f.fileid
-WHERE f.sha1 = %(hash)s
-OR f.md5 = %(hash)s
-;
+SELECT f.media_type, f.file
+FROM files AS f
+WHERE f.sha1 = %(hash)s OR f.md5 = %(hash)s;

--- a/cnxarchive/sql/migrations/20160128110515_mimetype_on_files_table.py
+++ b/cnxarchive/sql/migrations/20160128110515_mimetype_on_files_table.py
@@ -1,0 +1,33 @@
+# -*- coding: utf-8 -*-
+"""\
+- Add a ``media_type`` column to the ``files`` table.
+- Move the mimetype value from ``module_files`` to ``files``.
+
+"""
+from __future__ import print_function
+import sys
+
+
+def up(cursor):
+    # Add a ``media_type`` column to the ``files`` table.
+    cursor.execute("ALTER TABLE files ADD COLUMN media_type TEXT")
+
+    # Move the mimetype value from ``module_files`` to ``files``.
+    cursor.execute("UPDATE files AS f SET media_type = mf.mimetype "
+                   "FROM module_files AS mf "
+                   "WHERE mf.fileid = f.fileid")
+
+    # Warn about missing mimetype.
+    cursor.execute("SELECT fileid, sha1 "
+                   "FROM files AS f "
+                   "WHERE f.fileid NOT IN (SELECT fileid FROM module_files)")
+    rows = '\n'.join(['{}, {}'.format(fid, sha1)
+                      for fid, sha1 in cursor.fetchall()])
+    print("These files (fileid, sha1) do not have a corresponding "
+          "module_files entry:\n{}\n".format(rows),
+          file=sys.stderr)
+
+
+def down(cursor):
+    # Remove the ``mimetype`` column from the ``files`` table.
+    cursor.execute("ALTER TABLE files DROP COLUMN media_type")

--- a/cnxarchive/sql/migrations/20160128111115_mimetype_removal_from_module_files.py
+++ b/cnxarchive/sql/migrations/20160128111115_mimetype_removal_from_module_files.py
@@ -1,0 +1,41 @@
+# -*- coding: utf-8 -*-
+"""\
+- Move the mimetype value from ``module_files`` to ``files``.
+- Remove the ``mimetype`` column from the ``module_files`` table.
+
+"""
+from __future__ import print_function
+import sys
+
+
+def up(cursor):
+    # Move the mimetype value from ``module_files`` to ``files``.
+    cursor.execute("UPDATE files AS f SET media_type = mf.mimetype "
+                   "FROM module_files AS mf "
+                   "WHERE mf.fileid = f.fileid")
+
+    # Warn about missing mimetype.
+    cursor.execute("SELECT fileid, sha1 "
+                   "FROM files AS f "
+                   "WHERE f.fileid NOT IN (SELECT fileid FROM module_files)")
+    rows = '\n'.join(['{}, {}'.format(fid, sha1)
+                      for fid, sha1 in cursor.fetchall()])
+    print("These files (fileid, sha1) do not have a corresponding "
+          "module_files entry:\n{}\n".format(rows),
+          file=sys.stderr)
+
+    # Remove the ``mimetype`` column from the ``module_files`` table.
+    cursor.execute("ALTER TABLE module_files DROP COLUMN mimetype")
+
+
+def down(cursor):
+    # Add a ``mimetype`` column to the ``module_files`` table.
+    cursor.execute("ALTER TABLE module_files ADD COLUMN mimetype TEXT")
+
+    # Move the mimetype value from ``files`` to ``module_files``.
+    print("Rollback cannot accurately replace mimetype values that "
+          "were in the ``modules_files`` table.",
+          file=sys.stderr)
+    cursor.execute("UPDATE module_files AS mf SET mimetype = f.media_type "
+                   "FROM files AS f "
+                   "WHERE f.fileid = mf.fileid")

--- a/cnxarchive/sql/migrations/README.md
+++ b/cnxarchive/sql/migrations/README.md
@@ -1,0 +1,3 @@
+# Migrations
+
+This directory contains database migrations. The python scripts found in this directory are used in conjunction with db-migrator. See the db-migrator documentation for usage details.

--- a/cnxarchive/sql/schema/tables.sql
+++ b/cnxarchive/sql/schema/tables.sql
@@ -160,14 +160,14 @@ CREATE TABLE files (
     fileid serial PRIMARY KEY,
     md5 text,
     sha1 text,
-    file bytea
+    file bytea,
+    media_type text
 );
 
 CREATE TABLE module_files (
     module_ident integer references modules,
     fileid integer references files,
-    filename text,
-    mimetype text
+    filename text
 );
 
 CREATE TABLE modulecounts (

--- a/cnxarchive/tests/data/README.rst
+++ b/cnxarchive/tests/data/README.rst
@@ -1,8 +1,13 @@
 :data.sql:
     Generated via::
         cnx-archive-initdb cnxarchive/tests/testing.ini --with-example-data
-        (make needed changes)
-        pg_dump -a -T licenses -T tags -T roles --disable-triggers --inserts cnxarchive_testing > data.sql
+        # Initialize the schema manager
+        dbmigrator --config cnxarchive/tests/testing.ini init
+        # Create the schema migration step
+        dbmigrator generate <description of the change>
+        # Make needed changes via db-migrator migrations
+        dbmigrator --config cnxarchive/tests/testing.ini migrate
+        pg_dump -a -T licenses -T tags -T roles --disable-triggers --inserts cnxarchive-testing > data.sql
 
 
 

--- a/cnxarchive/tests/test_views.py
+++ b/cnxarchive/tests/test_views.py
@@ -158,15 +158,15 @@ COLLECTION_METADATA = {
     u'resources': [
         {u'filename': u'featured-cover.png',
          u'id': u'6214e8dcdf2824dbf830b4a0d77a3fa2f53608d2',
-         u'mimetype': u'image/png',
+         u'media_type': u'image/png',
          },
         {u'filename': u'collection.html',
          u'id': u'921dcf515d41c5a5cbe3c2163ed0f5db02ab3c83',
-         u'mimetype': u'text/html',
+         u'media_type': u'text/html',
          },
         {u'filename': u'collection.xml',
          u'id': u'921dcf515d41c5a5cbe3c2163ed0f5db02ab3c83',
-         u'mimetype': u'text/xml',
+         u'media_type': u'text/xml',
          },
         ],
     }
@@ -341,51 +341,51 @@ MODULE_METADATA = {
         u'tensile strength',
         ],
     u'resources': [
-        {u'mimetype': u'text/xml',
+        {u'media_type': u'text/xml',
          u'id': u'01b0137ec023558ef05c9a7ddc275cca055f3a65',
          u'filename': u'index_auto_generated.cnxml',
          },
-        {u'mimetype': u'image/jpg',
+        {u'media_type': u'image/jpg',
          u'id': u'03ab3d7bca387b142f226ea8b62e550b7a65a9e1',
          u'filename': u'Figure_06_03_09a.jpg',
          },
-        {u'mimetype': u'image/png',
+        {u'media_type': u'image/png',
          u'id': u'191d7161e775dacea2d0c2f81fa41f0eefd65eeb',
          u'filename': u'Figure_06_03_04a.jpg',
          },
-        {u'mimetype': u'image/jpg',
+        {u'media_type': u'image/jpg',
          u'id': u'3028d78f9f9d80f035bb4899cf8aa798d3befa79',
          u'filename': u'Figure_06_03_08a.jpg',
          },
-        {u'mimetype': u'image/jpg',
+        {u'media_type': u'image/jpg',
          u'id': u'4b832692d2a7318172d0c3d3a5986b1dc06aa2f5',
          u'filename': u'Figure_06_03_06a.jpg',
          },
-        {u'mimetype': u'image/png',
+        {u'media_type': u'image/png',
          u'id': u'8bebb2a5642cc453cbcca70f79fb2184e2976b60',
          u'filename': u'Figure_06_03_05_xa.jpg',
          },
-        {u'mimetype': u'image/jpg',
+        {u'media_type': u'image/jpg',
          u'id': u'95430b74a5ee9e09037c589feb0685ee226a06b8',
          u'filename': u'Figure_06_03_10a.jpg',
          },
-        {u'mimetype': u'text/xml',
+        {u'media_type': u'text/xml',
          u'id': u'9ae3b93679f6a4db2b78454189841d8ade98e0e6',
          u'filename': u'index.cnxml',
          },
-        {u'mimetype': u'text/html',
+        {u'media_type': u'text/html',
          u'id': u'b0bc75065bf8567c3cffc8221d4e3e92cc7b359b',
          u'filename': u'index.cnxml.html',
          },
-        {u'mimetype': u'image/jpg',
+        {u'media_type': u'image/jpg',
          u'id': u'b1504837b73dc2756173109e32344f0147c2921a',
          u'filename': u'Figure_06_03_02a.jpg',
          },
-        {u'mimetype': u'image/jpg',
+        {u'media_type': u'image/jpg',
          u'id': u'b1cae2957bab746ebaf065bd43f567509a446c3b',
          u'filename': u'Figure_06_03_01a.jpg',
          },
-        {u'mimetype': u'image/jpg',
+        {u'media_type': u'image/jpg',
          u'id': u'ff325274bcfa3be254a6cf39f86985df7ddaf294',
          u'filename': u'Figure_06_03_03a.jpg',
          },
@@ -1000,20 +1000,20 @@ class ViewsTestCase(unittest.TestCase):
         cursor.execute('ALTER TABLE module_files DISABLE TRIGGER ALL')
         cursor.execute('DELETE FROM module_files')
         # Insert a file for version 4
-        cursor.execute('''INSERT INTO files (file) VALUES
-            (%s) RETURNING fileid''', [memoryview('Version 4')])
+        cursor.execute('''INSERT INTO files (file, media_type) VALUES
+            (%s, 'text/html') RETURNING fileid''', [memoryview('Version 4')])
         fileid = cursor.fetchone()[0]
         cursor.execute('''INSERT INTO module_files
-                       (module_ident, fileid, filename, mimetype) VALUES
-                       (%s, %s, 'index.cnxml.html', 'text/html')''',
+                       (module_ident, fileid, filename) VALUES
+                       (%s, %s, 'index.cnxml.html')''',
                        [16, fileid])
         # Insert a file for version 5
-        cursor.execute('''INSERT INTO files (file) VALUES
-            (%s) RETURNING fileid''', [memoryview('Version 5')])
+        cursor.execute('''INSERT INTO files (file, media_type) VALUES
+            (%s, 'text/html') RETURNING fileid''', [memoryview('Version 5')])
         fileid = cursor.fetchone()[0]
         cursor.execute('''INSERT INTO module_files
-                       (module_ident, fileid, filename, mimetype) VALUES
-                       (%s, %s, 'index.cnxml.html', 'text/html')''',
+                       (module_ident, fileid, filename) VALUES
+                       (%s, %s, 'index.cnxml.html')''',
                        [15, fileid])
         cursor.connection.commit()
 

--- a/cnxarchive/tests/transforms/test_producers.py
+++ b/cnxarchive/tests/transforms/test_producers.py
@@ -156,8 +156,8 @@ VALUES
 
         # Insert the resource file
         cursor.execute("""\
-INSERT INTO module_files (module_ident, fileid, filename, mimetype)
-  SELECT %s, fileid, filename, mimetype FROM module_files
+INSERT INTO module_files (module_ident, fileid, filename)
+  SELECT %s, fileid, filename FROM module_files
   WHERE module_ident = 3 AND fileid = 6""", (document_ident,))
 
         # In the typical execution path, the target function
@@ -258,14 +258,16 @@ class ModuleToHtmlTestCase(unittest.TestCase):
         cursor.execute("DELETE FROM module_files WHERE module_ident = 2 "
                        "AND filename = 'index.cnxml.html'")
 
-        cursor.execute("INSERT INTO files (file) "
-                       "SELECT file FROM files natural join module_files "
+        cursor.execute("INSERT INTO files (file, media_type) "
+                       "SELECT file, media_type "
+                       "FROM files natural join module_files "
                        "WHERE filename = 'index.cnxml.html' "
                        "AND module_ident != 2 LIMIT 1 "
                        "RETURNING fileid")
         fileid = cursor.fetchone()[0]
-        cursor.execute('INSERT INTO module_files VALUES (2, '
-                       "%s, 'index.cnxml.html', 'text/html')", (fileid,))
+        cursor.execute("INSERT INTO module_files "
+                       "(module_ident, fileid, filename) "
+                       "VALUES (2, %s, 'index.cnxml.html')", (fileid,))
         cursor.connection.commit()
 
         msg = self.call_target(2, overwrite_html=True)
@@ -300,14 +302,16 @@ class ModuleToHtmlTestCase(unittest.TestCase):
         cursor.execute("DELETE FROM module_files WHERE module_ident = 2 "
                        "AND filename = 'index.cnxml.html'")
 
-        cursor.execute("INSERT INTO files (file) "
-                       "SELECT file FROM files natural join module_files "
+        cursor.execute("INSERT INTO files (file, media_type) "
+                       "SELECT file, media_type "
+                       "FROM files natural join module_files "
                        "WHERE filename = 'index.cnxml.html' "
                        "AND module_ident != 2 LIMIT 1 "
                        "RETURNING fileid")
         fileid = cursor.fetchone()[0]
-        cursor.execute('INSERT INTO module_files VALUES (2, '
-                       "%s, 'index.cnxml.html', 'text/html')", (fileid,))
+        cursor.execute("INSERT INTO module_files "
+                       "(module_ident, fileid, filename) "
+                       "VALUES (2, %s, 'index.cnxml.html')", (fileid,))
         cursor.connection.commit()
 
         from ...transforms.producers import IndexFileExistsError
@@ -576,12 +580,13 @@ class ModuleToCnxmlTestCase(unittest.TestCase):
         cursor.execute("DELETE FROM module_files WHERE module_ident = 2 "
                        "AND filename LIKE %s", ('%.cnxml',))
 
-        cursor.execute('INSERT INTO files (file) '
-                       '(SELECT file FROM files WHERE fileid = 1) '
+        cursor.execute('INSERT INTO files (file, media_type) '
+                       '(SELECT file, media_type FROM files WHERE fileid = 1) '
                        'RETURNING fileid')
         fileid = cursor.fetchone()[0]
-        cursor.execute('INSERT INTO module_files VALUES (2, '
-                       "%s, 'index.html.cnxml', 'text/xml')", (fileid,))
+        cursor.execute("INSERT INTO module_files "
+                       "(module_ident, fileid, filename) "
+                       "VALUES (2, %s, 'index.html.cnxml')", (fileid,))
         cursor.connection.commit()
 
         msg = self.call_target(2, overwrite=True)
@@ -616,12 +621,14 @@ class ModuleToCnxmlTestCase(unittest.TestCase):
         cursor.execute("DELETE FROM module_files WHERE module_ident = 2 "
                        "AND filename LIKE %s", ('%.cnxml',))
 
-        cursor.execute('INSERT INTO files (file) '
-                       'SELECT file FROM files WHERE fileid = 1 '
+        cursor.execute('INSERT INTO files (file, media_type) '
+                       'SELECT file, media_type '
+                       'FROM files WHERE fileid = 1 '
                        'RETURNING fileid')
         fileid = cursor.fetchone()[0]
-        cursor.execute('INSERT INTO module_files VALUES (2, '
-                       "%s, 'index.html.cnxml', 'text/xml')", (fileid,))
+        cursor.execute("INSERT INTO module_files "
+                       "(module_ident, fileid, filename) "
+                       "VALUES (2, %s, 'index.html.cnxml')", (fileid,))
         cursor.connection.commit()
 
         from ...transforms.producers import IndexFileExistsError
@@ -654,12 +661,14 @@ class ModuleToCnxmlTestCase(unittest.TestCase):
         cursor.execute("DELETE FROM module_files WHERE module_ident = 2 "
                        "AND filename LIKE %s", ('%.cnxml',))
 
-        cursor.execute('INSERT INTO files (file) '
-                       'SELECT file FROM files WHERE fileid = 1 '
+        cursor.execute('INSERT INTO files (file, media_type) '
+                       'SELECT file, media_type '
+                       'FROM files WHERE fileid = 1 '
                        'RETURNING fileid')
         fileid = cursor.fetchone()[0]
-        cursor.execute('INSERT INTO module_files VALUES (2, '
-                       "%s, 'index.html.cnxml', 'text/xml')", (fileid,))
+        cursor.execute("INSERT INTO module_files "
+                       "(module_ident, fileid, filename) "
+                       "VALUES (2, %s, 'index.html.cnxml')", (fileid,))
         cursor.connection.commit()
 
         from ...transforms.producers import IndexFileExistsError

--- a/setup.py
+++ b/setup.py
@@ -46,6 +46,8 @@ setup(
     [console_scripts]
     cnx-archive-initdb = cnxarchive.scripts.initializedb:main
     cnx-archive-hits_counter = cnxarchive.scripts.hits_counter:main
+    [dbmigrator]
+    migrations_directory = cnxarchive:find_migrations_directory
     """,
     test_suite='cnxarchive.tests'
     )


### PR DESCRIPTION
This puts the mime-type (aka media type and content type) on the files table.

This adds the db-migrator feature to this project. Please review this part of the pull request carefully.