### PR TITLE
Raise ident hash syntax error if ident hash ends with @

### DIFF
--- a/cnxarchive/tests/test_functional.py
+++ b/cnxarchive/tests/test_functional.py
@@ -37,6 +37,14 @@ class FunctionalTestCase(unittest.TestCase):
 
 
 class IdentHashSyntaxErrorTestCase(FunctionalTestCase):
+    fixture = testing.data_fixture
+
+    def setUp(self):
+        self.fixture.setUp()
+
+    def tearDown(self):
+        self.fixture.tearDown()
+
     def test_get_export_invalid_id(self):
         self.testapp.get('/exports/abcd.pdf', status=404)
 
@@ -50,6 +58,29 @@ class IdentHashSyntaxErrorTestCase(FunctionalTestCase):
     def test_in_book_search_highlighted_results_invalid_id(self):
         self.testapp.get('/search/abcd:efgh?q=air+or+liquid+drag',
                          status=404)
+
+    def test_contents_uuid_only_w_at_sign(self):
+        uuid = '56f1c5c1-4014-450d-a477-2121e276beca'
+        resp = self.testapp.get('/contents/{}@'.format(uuid))
+        self.assertEqual(resp.status, '302 Found')
+        self.assertEqual(
+            unquote(resp.location),
+            'http://localhost/contents/{}@8'.format(uuid))
+
+    def test_contents_short_id_only_w_at_sign(self):
+        uuid = '56f1c5c1-4014-450d-a477-2121e276beca'
+        short_id = CNXHash(uuid).get_shortid()
+        resp = self.testapp.get('/contents/{}@'.format(short_id))
+        self.assertEqual(resp.status, '302 Found')
+        self.assertEqual(
+            unquote(resp.location),
+            'http://localhost/contents/{}@8'.format(uuid))
+
+    def test_contents_invalid_id_w_at_sign(self):
+        self.testapp.get('/contents/a@', status=404)
+
+    def test_contents_w_only_at_sign(self):
+        self.testapp.get('/contents/@', status=404)
 
 
 class IdentHashShortIdTestCase(FunctionalTestCase):

--- a/cnxarchive/tests/test_utils.py
+++ b/cnxarchive/tests/test_utils.py
@@ -23,7 +23,7 @@ class SplitIdentTestCase(unittest.TestCase):
         # Case of supplying the utility function with an empty indent-hash.
         ident_hash = ''
 
-        with self.assertRaises(ValueError):
+        with self.assertRaises(IdentHashSyntaxError):
             self.call_target(ident_hash)
 
     def test_complete_data(self):
@@ -39,12 +39,19 @@ class SplitIdentTestCase(unittest.TestCase):
         self.assertEqual(id, expected_id)
         self.assertEqual(version, expected_version)
 
+    def test_uuid_only_w_at_sign(self):
+        expected_id = '85e57f79-02b3-47d2-8eed-c1bbb1e1d5c2'
+        ident_hash = "{}@".format(expected_id)
+
+        with self.assertRaises(IdentHashSyntaxError) as cm:
+            self.call_target(ident_hash)
+
     def test_uuid_only(self):
         # Case where the UUID has been the only value supplied in the
         # ident-hash.
         # This is mostly testing that the version value returns None.
         expected_id = '85e57f79-02b3-47d2-8eed-c1bbb1e1d5c2'
-        ident_hash = "{}@".format(expected_id)
+        ident_hash = expected_id
 
         with self.assertRaises(IdentHashMissingVersion) as cm:
             self.call_target(ident_hash)

--- a/cnxarchive/utils/ident_hash.py
+++ b/cnxarchive/utils/ident_hash.py
@@ -25,12 +25,15 @@ __all__ = (
 
 class IdentHashError(Exception):
     """Base exception class for all ident hash exceptions."""
+    def __str__(self):
+        return self.msg
 
 
 class IdentHashSyntaxError(IdentHashError):
     """Raised when the ident-hash syntax is incorrect."""
     def __init__(self, ident_hash):
         self.ident_hash = ident_hash
+        self.msg = 'ident_hash={}'.format(ident_hash)
 
 
 class IdentHashShortId(IdentHashError):
@@ -38,12 +41,14 @@ class IdentHashShortId(IdentHashError):
     def __init__(self, id, version):
         self.id = id
         self.version = version
+        self.msg = 'id={} version={}'.format(id, version)
 
 
 class IdentHashMissingVersion(IdentHashError):
     """Raised when the ident-hash does not have a version"""
     def __init__(self, id):
         self.id = id
+        self.msg = 'id={}'.format(id)
 
 
 def split_legacy_hash(legacy_hash):

--- a/cnxarchive/utils/ident_hash.py
+++ b/cnxarchive/utils/ident_hash.py
@@ -29,6 +29,8 @@ class IdentHashError(Exception):
 
 class IdentHashSyntaxError(IdentHashError):
     """Raised when the ident-hash syntax is incorrect."""
+    def __init__(self, ident_hash):
+        self.ident_hash = ident_hash
 
 
 class IdentHashShortId(IdentHashError):
@@ -56,19 +58,17 @@ def split_legacy_hash(legacy_hash):
 
 def split_ident_hash(ident_hash, split_version=False):
     """Returns a valid id and version from the <id>@<version> hash syntax."""
-    if HASH_CHAR not in ident_hash:
-        ident_hash = '{}@'.format(ident_hash)
     split_value = ident_hash.split(HASH_CHAR)
-    if split_value[0] == '':
-        raise ValueError("Missing values")
 
-    try:
-        id, version = split_value
-    except ValueError:
+    if len(split_value) > 2 or '' in split_value:
         raise IdentHashSyntaxError(ident_hash)
 
-    # Validate the id.
+    if len(split_value) == 1:
+        id, version = split_value[0], ''
+    else:
+        id, version = split_value
 
+    # Validate the id.
     id_type = CNXHash.validate(id)
 
     if id_type == CNXHash.SHORTID:
@@ -76,6 +76,8 @@ def split_ident_hash(ident_hash, split_version=False):
 
     if not version:
         raise IdentHashMissingVersion(id)
+
+    version = split_value[1]
 
     if split_version:
         split_version = version.split(VERSION_CHAR)
@@ -164,18 +166,18 @@ class CNXHash(uuid.UUID):
                          cls._SHORT_HASH_LENGTH)
                     cls.base642uuid(hash_id)
                 except (TypeError, ValueError):
-                    raise IdentHashSyntaxError
+                    raise IdentHashSyntaxError(hash_id)
                 return cls.SHORTID
             elif len(hash_id) == cls._MAX_SHORT_HASH_LENGTH:
                 try:
                     cls.base642uuid(hash_id)
                 except (TypeError, ValueError):
-                    raise IdentHashSyntaxError
+                    raise IdentHashSyntaxError(hash_id)
                 return cls.BASE64HASH
             else:  # See if it's a string repr of a uuid
                 try:
                     cls.uuid2base64(hash_id)
                 except (TypeError, ValueError):
-                    raise IdentHashSyntaxError
+                    raise IdentHashSyntaxError(hash_id)
                 return cls.FULLUUID
-        raise IdentHashSyntaxError
+        raise IdentHashSyntaxError(hash_id)

--- a/cnxarchive/views.py
+++ b/cnxarchive/views.py
@@ -394,6 +394,15 @@ def _get_licenses(cursor):
 
 @view_config(context=IdentHashSyntaxError)
 def ident_hash_syntax_error(exc, request):
+    if exc.ident_hash.endswith('@'):
+        try:
+            split_ident_hash(exc.ident_hash[:-1])
+        except IdentHashShortId as e:
+            return ident_hash_short_id(e, request)
+        except IdentHashMissingVersion as e:
+            return ident_hash_missing_version(e, request)
+        except IdentHashSyntaxError:
+            pass
     return httpexceptions.HTTPNotFound()
 
 


### PR DESCRIPTION
Change ident hash syntax error exception view to try again with the
ident hash without the @ sign.