### PR TITLE
improve triggers on files table

### DIFF
--- a/cnxarchive/sql/migrations/20160128111115_mimetype_removal_from_module_files.py
+++ b/cnxarchive/sql/migrations/20160128111115_mimetype_removal_from_module_files.py
@@ -12,7 +12,7 @@ def up(cursor):
     # Move the mimetype value from ``module_files`` to ``files``.
     cursor.execute("UPDATE files AS f SET media_type = mf.mimetype "
                    "FROM module_files AS mf "
-                   "WHERE mf.fileid = f.fileid")
+                   "WHERE mf.fileid = f.fileid AND f.media_type IS NULL")
 
     # Warn about missing mimetype.
     cursor.execute("SELECT fileid, sha1 "

--- a/cnxarchive/sql/schema/triggers.sql
+++ b/cnxarchive/sql/schema/triggers.sql
@@ -182,7 +182,7 @@ $$
     LANGUAGE plpgsql;
 
 CREATE TRIGGER update_file_md5
-    BEFORE INSERT OR UPDATE ON files
+    BEFORE INSERT OR UPDATE OF file ON files
     FOR EACH ROW
     EXECUTE PROCEDURE update_md5();
 
@@ -196,7 +196,7 @@ AS $$
 $$ LANGUAGE plpythonu;
 
 CREATE TRIGGER update_files_sha1
-    BEFORE INSERT OR UPDATE ON files
+    BEFORE INSERT OR UPDATE OF file ON files
     FOR EACH ROW
     EXECUTE PROCEDURE update_sha1();
 


### PR DESCRIPTION
firing the triggers every time slows the migration phenomenally. Made them conditional on the file attribute changing. Updating all files media_types took 39 sec w/ selective triggers, 35 sec with no triggers, and never completed with existing triggers (interrupted at 17 minutes)