### PR TITLE
Fix SQL syntax error in migrations

### DIFF
--- a/cnxarchive/sql/migrations/20160128110515_mimetype_on_files_table.py
+++ b/cnxarchive/sql/migrations/20160128110515_mimetype_on_files_table.py
@@ -23,13 +23,13 @@ def up(cursor):
 
     # Put triggers back
     cursor.execute("CREATE TRIGGER update_file_md5 "
-                   "BEFORE INSERT OR UPDATE OF file ON files"
-                   "FOR EACH ROW"
+                   "BEFORE INSERT OR UPDATE OF file ON files "
+                   "FOR EACH ROW "
                    "EXECUTE PROCEDURE update_md5()")
 
-    cursor.execute("CREATE TRIGGER update_files_sha1"
-                   "BEFORE INSERT OR UPDATE OF file ON files"
-                   "FOR EACH ROW"
+    cursor.execute("CREATE TRIGGER update_files_sha1 "
+                   "BEFORE INSERT OR UPDATE OF file ON files "
+                   "FOR EACH ROW "
                    "EXECUTE PROCEDURE update_sha1()")
 
     # Warn about missing mimetype.
@@ -53,11 +53,11 @@ def down(cursor):
 
     # Put triggers back
     cursor.execute("CREATE TRIGGER update_file_md5 "
-                   "BEFORE INSERT OR UPDATE ON files"
-                   "FOR EACH ROW"
+                   "BEFORE INSERT OR UPDATE ON files "
+                   "FOR EACH ROW "
                    "EXECUTE PROCEDURE update_md5()")
 
-    cursor.execute("CREATE TRIGGER update_files_sha1"
-                   "BEFORE INSERT OR UPDATE ON files"
-                   "FOR EACH ROW"
+    cursor.execute("CREATE TRIGGER update_files_sha1 "
+                   "BEFORE INSERT OR UPDATE ON files "
+                   "FOR EACH ROW "
                    "EXECUTE PROCEDURE update_sha1()")


### PR DESCRIPTION
Simple fix for a SQL syntax error introduced in #408. Sorry, this is my fault for not catching it before I pushed the merge button. :confounded: 