### PR TITLE
Fix to close the epub export zipfile

### DIFF
--- a/cnxarchive/scripts/export_epub/main.py
+++ b/cnxarchive/scripts/export_epub/main.py
@@ -24,9 +24,12 @@ def main(argv=None):
     parser.add_argument('ident_hash',
                         help="ident-hash of the content ")
     parser.add_argument('file', type=argparse.FileType('wb'),
-                        help="output file (use '-' for stdout)")
+                        help="output file")
     args = parser.parse_args(argv)
 
+    if args.file is sys.stdout:
+        raise RuntimeError("Can't stream a zipfile to stdout "
+                           "because it will have issues closing")
     env = bootstrap(args.config_uri)
 
     create_epub(args.ident_hash, args.file)

--- a/cnxarchive/tests/scripts/test_export_epub.py
+++ b/cnxarchive/tests/scripts/test_export_epub.py
@@ -686,3 +686,12 @@ class MainTestCase(BaseTestCase):
                 'resources/4bfac6b2934befce939cb70321bba1fb414543b5',
                 ]
             self.assert_contains(zf.namelist(), expected_to_contain)
+
+    def test_failure_using_stdout(self):
+        args = (testing.config_uri(), self.module_ident_hash, '-')
+        try:
+            self.target(args)
+        except RuntimeError as exc:
+            self.assertIn('stdout', exc.args[0])
+        else:
+            self.fail("should have failed to use stdout")


### PR DESCRIPTION
We can't use `sys.stdout` for this because the `zipfile.ZipFile.close`
method needs to seek in order to write some cataloging bits.