### PR TITLE
Unique files table entries

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,10 @@ addons:
 services:
   - memcached
 before_install:
+  - pip install pep8
+  - pep8 --exclude=tests *.py cnxarchive/
+  - pep8 --max-line-length=200 cnxarchive/tests
+
   - sudo apt-get update
   # Remove python-zope.interface, not compatible with the pyramid version we're
   # using
@@ -40,10 +44,6 @@ before_script:
   - sudo -u postgres psql -d postgres -c "CREATE USER cnxarchive WITH SUPERUSER PASSWORD 'cnxarchive';"
   # Set up the database
   - sudo -u postgres createdb -O cnxarchive cnxarchive-testing
-  - pip install pep8
-  - pep8 --exclude=tests *.py cnxarchive/
-  - pep8 --max-line-length=200 cnxarchive/tests
-
   - git clone https://github.com/okbob/session_exec
   - cd session_exec
   - make USE_PGXS=1 -e && sudo make USE_PGXS=1 -e install

--- a/cnxarchive/sql/migrations/20160308064742_unique_files_by_sha1.py
+++ b/cnxarchive/sql/migrations/20160308064742_unique_files_by_sha1.py
@@ -1,0 +1,36 @@
+# -*- coding: utf-8 -*-
+"""\
+- Migrate all `module_files` records to a single `files` entry.
+- Fix the `files` table to only allow one copy of a file.
+
+"""
+
+
+def up(cursor):
+    # Migrate all `module_files` records to a single `files` entry.
+    cursor.execute("""\
+WITH grouped_files AS (
+  SELECT f.sha1, array_agg(f.fileid ORDER BY f.fileid ASC) AS fileids
+  FROM files AS f
+  WHERE (SELECT DISTINCT count(*) FROM files AS f2 WHERE f.sha1 = f2.sha1) > 1
+  GROUP BY f.sha1
+),
+for_removal AS (
+  SELECT unnest(gf.fileids[2:array_length(gf.fileids,1)]) AS fileid
+  FROM grouped_files as gf
+),
+updated_files as (
+  UPDATE module_files AS mf
+  SET fileid = gf.fileids[1]
+  FROM grouped_files AS gf
+  WHERE mf.fileid = any(gf.fileids)
+  RETURNING mf.fileid
+)
+DELETE FROM files WHERE fileid IN (SELECT fileid FROM for_removal)
+""")
+    # Fix the `files` table to only allow one copy of a file.
+    cursor.execute("ALTER TABLE files ADD UNIQUE (sha1)")
+
+
+def down(cursor):
+    pass

--- a/cnxarchive/sql/schema/tables.sql
+++ b/cnxarchive/sql/schema/tables.sql
@@ -159,7 +159,7 @@ CREATE TABLE "modulekeywords" (
 CREATE TABLE files (
     fileid serial PRIMARY KEY,
     md5 text,
-    sha1 text,
+    sha1 text UNIQUE,
     file bytea,
     media_type text
 );

--- a/cnxarchive/tests/test_database.py
+++ b/cnxarchive/tests/test_database.py
@@ -6,6 +6,7 @@
 # See LICENCE.txt for details.
 # ###
 import datetime
+import hashlib
 import os
 import sys
 import time
@@ -928,10 +929,16 @@ ALTER TABLE modules DISABLE TRIGGER module_published""")
         ''')
 
         for data, filename, media_type in cursor.fetchall():
-            cursor.execute('''INSERT INTO files (file, media_type)
-            VALUES (%s, %s)
-            RETURNING fileid''', (data, media_type,))
-            fileid = cursor.fetchone()[0]
+            sha1 = hashlib.new('sha1', data[:]).hexdigest()
+            cursor.execute("SELECT fileid from files where sha1 = %s",
+                           (sha1,))
+            try:
+                fileid = cursor.fetchone()[0]
+            except TypeError:
+                cursor.execute('''INSERT INTO files (file, media_type)
+                VALUES (%s, %s)
+                RETURNING fileid''', (data, media_type,))
+                fileid = cursor.fetchone()[0]
             cursor.execute('''\
             INSERT INTO module_files (module_ident, fileid, filename)
             VALUES (%s, %s, %s)''',
@@ -939,11 +946,9 @@ ALTER TABLE modules DISABLE TRIGGER module_published""")
 
         # Insert index.cnxml only after adding all the other files
         cursor.execute('''\
-        INSERT INTO files (file, media_type)
-            SELECT f.file, f.media_type
-            FROM module_files m JOIN files f ON m.fileid = f.fileid
-            WHERE m.module_ident = 3 AND m.filename = 'index.cnxml'
-        RETURNING fileid
+        SELECT fileid
+        FROM module_files
+        WHERE module_ident = 3 AND filename = 'index.cnxml'
         ''')
         fileid = cursor.fetchone()[0]
         cursor.execute('''\
@@ -1010,20 +1015,25 @@ ALTER TABLE modules DISABLE TRIGGER module_published""")
         ''')
 
         for data, filename, media_type in cursor.fetchall():
-            cursor.execute('''INSERT INTO files (file, media_type)
-            VALUES (%s, %s) RETURNING fileid''', (data, media_type,))
-            fileid = cursor.fetchone()[0]
+            sha1 = hashlib.new('sha1', data[:]).hexdigest()
+            cursor.execute("SELECT fileid from files where sha1 = %s",
+                           (sha1,))
+            try:
+                fileid = cursor.fetchone()[0]
+            except TypeError:
+                cursor.execute('''INSERT INTO files (file, media_type)
+                VALUES (%s, %s)
+                RETURNING fileid''', (data, media_type,))
+                fileid = cursor.fetchone()[0]
             cursor.execute('''
             INSERT INTO module_files (module_ident, fileid, filename)
             VALUES (%s, %s, %s)''', (new_module_ident, fileid, filename,))
 
         # Insert index.cnxml.html only after adding all the other files
         cursor.execute('''
-        INSERT INTO files (file, media_type)
-            SELECT f.file, f.media_type
-            FROM module_files m JOIN files f ON m.fileid = f.fileid
-            WHERE m.module_ident = 3 AND m.filename = 'index.cnxml.html'
-        RETURNING fileid
+        SELECT fileid
+        FROM module_files
+        WHERE module_ident = 3 AND filename = 'index.cnxml.html'
         ''')
         fileid = cursor.fetchone()[0]
         cursor.execute('''
@@ -1101,21 +1111,25 @@ ALTER TABLE modules DISABLE TRIGGER module_published""")
         ''')
 
         for data, filename, media_type in cursor.fetchall():
-            cursor.execute('''INSERT INTO files (file, media_type)
-            VALUES (%s, %s)
-            RETURNING fileid''', (data, media_type))
-            fileid = cursor.fetchone()[0]
+            sha1 = hashlib.new('sha1', data[:]).hexdigest()
+            cursor.execute("SELECT fileid from files where sha1 = %s",
+                           (sha1,))
+            try:
+                fileid = cursor.fetchone()[0]
+            except TypeError:
+                cursor.execute('''INSERT INTO files (file, media_type)
+                VALUES (%s, %s)
+                RETURNING fileid''', (data, media_type,))
+                fileid = cursor.fetchone()[0]
             cursor.execute('''
             INSERT INTO module_files (module_ident, fileid, filename)
             VALUES (%s, %s, %s)''', (new_module_ident, fileid, filename))
 
         # Insert index.cnxml only after adding all the other files
         cursor.execute('''
-        INSERT INTO files (file, media_type)
-            SELECT f.file, f.media_type
-            FROM module_files m JOIN files f ON m.fileid = f.fileid
-            WHERE m.module_ident = 3 AND m.filename = 'index.cnxml'
-        RETURNING fileid
+        SELECT fileid
+        FROM module_files
+        WHERE module_ident = 3 AND filename = 'index.cnxml'
         ''')
         fileid = cursor.fetchone()[0]
         cursor.execute('''

--- a/cnxarchive/tests/test_views.py
+++ b/cnxarchive/tests/test_views.py
@@ -160,9 +160,10 @@ COLLECTION_METADATA = {
          u'id': u'6214e8dcdf2824dbf830b4a0d77a3fa2f53608d2',
          u'media_type': u'image/png',
          },
+        # FIXME This file probably shouldn't exist?
         {u'filename': u'collection.html',
          u'id': u'921dcf515d41c5a5cbe3c2163ed0f5db02ab3c83',
-         u'media_type': u'text/html',
+         u'media_type': u'text/xml',
          },
         {u'filename': u'collection.xml',
          u'id': u'921dcf515d41c5a5cbe3c2163ed0f5db02ab3c83',

--- a/cnxarchive/tests/transforms/test_producers.py
+++ b/cnxarchive/tests/transforms/test_producers.py
@@ -258,12 +258,10 @@ class ModuleToHtmlTestCase(unittest.TestCase):
         cursor.execute("DELETE FROM module_files WHERE module_ident = 2 "
                        "AND filename = 'index.cnxml.html'")
 
-        cursor.execute("INSERT INTO files (file, media_type) "
-                       "SELECT file, media_type "
-                       "FROM files natural join module_files "
+        cursor.execute("SELECT fileid "
+                       "FROM module_files "
                        "WHERE filename = 'index.cnxml.html' "
-                       "AND module_ident != 2 LIMIT 1 "
-                       "RETURNING fileid")
+                       "AND module_ident != 2 LIMIT 1")
         fileid = cursor.fetchone()[0]
         cursor.execute("INSERT INTO module_files "
                        "(module_ident, fileid, filename) "
@@ -302,12 +300,10 @@ class ModuleToHtmlTestCase(unittest.TestCase):
         cursor.execute("DELETE FROM module_files WHERE module_ident = 2 "
                        "AND filename = 'index.cnxml.html'")
 
-        cursor.execute("INSERT INTO files (file, media_type) "
-                       "SELECT file, media_type "
-                       "FROM files natural join module_files "
+        cursor.execute("SELECT fileid "
+                       "FROM module_files "
                        "WHERE filename = 'index.cnxml.html' "
-                       "AND module_ident != 2 LIMIT 1 "
-                       "RETURNING fileid")
+                       "AND module_ident != 2 LIMIT 1")
         fileid = cursor.fetchone()[0]
         cursor.execute("INSERT INTO module_files "
                        "(module_ident, fileid, filename) "
@@ -580,10 +576,7 @@ class ModuleToCnxmlTestCase(unittest.TestCase):
         cursor.execute("DELETE FROM module_files WHERE module_ident = 2 "
                        "AND filename LIKE %s", ('%.cnxml',))
 
-        cursor.execute('INSERT INTO files (file, media_type) '
-                       '(SELECT file, media_type FROM files WHERE fileid = 1) '
-                       'RETURNING fileid')
-        fileid = cursor.fetchone()[0]
+        fileid = 1
         cursor.execute("INSERT INTO module_files "
                        "(module_ident, fileid, filename) "
                        "VALUES (2, %s, 'index.html.cnxml')", (fileid,))
@@ -621,11 +614,7 @@ class ModuleToCnxmlTestCase(unittest.TestCase):
         cursor.execute("DELETE FROM module_files WHERE module_ident = 2 "
                        "AND filename LIKE %s", ('%.cnxml',))
 
-        cursor.execute('INSERT INTO files (file, media_type) '
-                       'SELECT file, media_type '
-                       'FROM files WHERE fileid = 1 '
-                       'RETURNING fileid')
-        fileid = cursor.fetchone()[0]
+        fileid = 1
         cursor.execute("INSERT INTO module_files "
                        "(module_ident, fileid, filename) "
                        "VALUES (2, %s, 'index.html.cnxml')", (fileid,))
@@ -661,11 +650,7 @@ class ModuleToCnxmlTestCase(unittest.TestCase):
         cursor.execute("DELETE FROM module_files WHERE module_ident = 2 "
                        "AND filename LIKE %s", ('%.cnxml',))
 
-        cursor.execute('INSERT INTO files (file, media_type) '
-                       'SELECT file, media_type '
-                       'FROM files WHERE fileid = 1 '
-                       'RETURNING fileid')
-        fileid = cursor.fetchone()[0]
+        fileid = 1
         cursor.execute("INSERT INTO module_files "
                        "(module_ident, fileid, filename) "
                        "VALUES (2, %s, 'index.html.cnxml')", (fileid,))


### PR DESCRIPTION
This will deduplication files table entries and prevent them from happening in the future. This also contains a change to move the pep8 checks to the top of the travis config so that it fails fast.

For example:
```
                   sha1                   |  c
------------------------------------------+-----
 075500ad9f71890a85fe3f7a4137ac08e2b7907c | 186
 e0a621ecbb46ba16a9235263be5233eb0e6897c3 | 158
 40f706929ab55ad5d247f69b7b0918ddb9c49c58 | 137
 fff772d27029cb8e720c8be9db336c968f835d22 | 108
 4efceebae7d0d4e155a8ef775667a984ca76cbff | 101
 4e3c963bada0fbd8c67016a375bb44550a5ae295 |  71
 6e272a9430637f03e127ab214497cf3ba0666a3d |  71
 64690f3ebc5dd10a7c4718cbd4d2f1113b0155a6 |  65
...
```
Where `c` is the duplication count.

Note, there is no rollback for this. I could have put one in, but frankly it's way more work than it's worth. It may be faster to restore from backup if things went horribly wrong.