### PR TITLE
Fix document factory error when resource uri doesn't have a filename

### DIFF
--- a/cnxarchive/scripts/export_epub/modeling.py
+++ b/cnxarchive/scripts/export_epub/modeling.py
@@ -39,6 +39,9 @@ def document_factory(ident_hash, context=None):
            or not ref.uri.startswith('/resources/'):
             continue
         hash, filename = ref.uri.split('/')[-2:]
+        if hash == 'resources':
+            # if ref.uri is just /resources/hash (without filename)
+            hash = filename
         resource = resources_map[hash]
         ref.bind(resource, '/resources/{}')
     return doc


### PR DESCRIPTION
Resource uris don't have a filename when users use the webview editor and
cnx-publishing to publish a new document.

```
karen@cte-cnx-dev:~$ /var/cnx/venvs/archive/bin/cnx-archive-export_epub /etc/cnx/archive/app.ini 06106b3c-0e0a-45e6-8c18-0ca0f9ebb902@2.1 06106b3c-0e0a-45e6-8c18-0ca0f9ebb902@2.1.epub
Traceback (most recent call last):
  File "/var/cnx/venvs/archive/bin/cnx-archive-export_epub", line 9, in <module>
    load_entry_point('cnx-archive==2.5.1', 'console_scripts', 'cnx-archive-export_epub')()
  File "/var/cnx/venvs/archive/local/lib/python2.7/site-packages/cnxarchive/scripts/export_epub/main.py", line 35, in main
    create_epub(args.ident_hash, args.file)
  File "/var/cnx/venvs/archive/local/lib/python2.7/site-packages/cnxarchive/scripts/export_epub/modeling.py", line 123, in create_epub
    model = factory(ident_hash)
  File "/var/cnx/venvs/archive/local/lib/python2.7/site-packages/cnxarchive/scripts/export_epub/modeling.py", line 114, in factory
    return factory_callable(ident_hash)
  File "/var/cnx/venvs/archive/local/lib/python2.7/site-packages/cnxarchive/scripts/export_epub/modeling.py", line 93, in binder_factory
    nodes = tree_to_nodes(tree)
  File "/var/cnx/venvs/archive/local/lib/python2.7/site-packages/cnxarchive/scripts/export_epub/modeling.py", line 86, in tree_to_nodes
    nodes.append(document_factory(item['id'], context=context))
  File "/var/cnx/venvs/archive/local/lib/python2.7/site-packages/cnxarchive/scripts/export_epub/modeling.py", line 42, in document_factory
    resource = resources_map[hash]
KeyError: 'resources'
```