### PR TITLE
Add cnx-archive-init_venv to set up python venv on postgres

### DIFF
--- a/cnxarchive/scripts/export_epub/modeling.py
+++ b/cnxarchive/scripts/export_epub/modeling.py
@@ -39,6 +39,9 @@ def document_factory(ident_hash, context=None):
            or not ref.uri.startswith('/resources/'):
             continue
         hash, filename = ref.uri.split('/')[-2:]
+        if hash == 'resources':
+            # if ref.uri is just /resources/hash (without filename)
+            hash = filename
         resource = resources_map[hash]
         ref.bind(resource, '/resources/{}')
     return doc

--- a/cnxarchive/scripts/init_venv.py
+++ b/cnxarchive/scripts/init_venv.py
@@ -1,0 +1,132 @@
+# -*- coding: utf-8 -*-
+import os
+import logging
+import sys
+import warnings
+
+import psycopg2
+
+from cnxarchive import config
+from cnxarchive.scripts._utils import (
+    create_parser, get_app_settings_from_arguments,
+    )
+
+
+# The code is copied from https://github.com/pumazi/cnx-db/
+# blob/454ee6a67ae265ac5dc1010248b9f3f1c7fd1722/cnxdb/init/main.py
+# Can remove when we start using cnx-db in cnx-archive.
+
+
+logger = logging.getLogger('cnxarchive')
+
+
+ACTIVATE_VENV_SQL_FUNCTION = """\
+CREATE FUNCTION venv.activate_venv()
+RETURNS void LANGUAGE plpythonu AS $_$
+import sys
+import os
+import site
+old_os_path = os.environ.get('PATH','')
+os.environ['PATH'] = os.path.dirname(os.path.abspath('{activate_path}')) \
++ os.pathsep + old_os_path
+base = os.path.dirname(os.path.dirname(os.path.abspath('{activate_path}')))
+site_packages = os.path.join(base, 'lib', 'python%s' % sys.version[:3], \
+'site-packages')
+prev_sys_path = list(sys.path)
+site.addsitedir(site_packages)
+sys.real_prefix = sys.prefix
+sys.prefix = base
+# Move the added items to the front of the path:
+new_sys_path = []
+for item in list(sys.path):
+    if item not in prev_sys_path:
+        new_sys_path.append(item)
+        sys.path.remove(item)
+sys.path[:0] = new_sys_path
+$_$"""
+
+
+def _is_localhost_connection(db_connection):
+    """Given a database connection, check this is a connection to localhost.
+
+    """
+    # If you are connecting to a database that is not localhost,
+    # don't initalize with virtualenv
+    db_dict = dict(p.split('=') for p in db_connection.dsn.split())
+    return db_dict.get('host', 'localhost') != 'localhost'
+
+
+def init_venv(connection_string):
+    """Initialize a Python virtual environment for trigger importation."""
+    # If virtualenv is active, use that for postgres
+    if hasattr(sys, 'real_prefix'):  # attr is only present within a venv
+        activate_path = os.path.join(os.path.realpath(sys.prefix),
+                                     'bin/activate_this.py')
+    else:  # pragma: no cover
+        return
+
+    with psycopg2.connect(connection_string) as db_connection:
+        if _is_localhost_connection(db_connection):  # pragma: no cover
+            warnings.warn("An attempt to use ``init_venv`` was made, "
+                          "but not on the same host as the postgres service.")
+            return
+        with db_connection.cursor() as cursor:
+            cursor.execute("SELECT current_database();")
+            db_name = cursor.fetchone()[0]
+
+            cursor.execute("SELECT schema_name "
+                           "FROM information_schema.schemata "
+                           "WHERE schema_name = 'venv';")
+            try:
+                schema_exists = cursor.fetchone()[0]
+            except TypeError:
+                cursor.execute("CREATE SCHEMA venv")
+                try:
+                    cursor.execute("SAVEPOINT session_preload")
+                    cursor.execute("ALTER DATABASE \"{}\" SET "
+                                   "session_preload_libraries ="
+                                   "'session_exec'".format(db_name))
+                except psycopg2.ProgrammingError as e:  # pragma: no cover
+                    if e.message.startswith(
+                            'unrecognized configuration parameter'):
+
+                        cursor.execute("ROLLBACK TO SAVEPOINT "
+                                       "session_preload")
+                        logger.warning("Postgresql < 9.4: make sure "
+                                       "to set "
+                                       "'local_preload_libraries "
+                                       "= session_exec' in "
+                                       "postgresql.conf and restart")
+                    else:  # pragma: no cover
+                        raise
+
+                cursor.execute("ALTER DATABASE \"{}\" "
+                               "SET session_exec.login_name = "
+                               "'venv.activate_venv'"
+                               .format(db_name))
+                sql = ACTIVATE_VENV_SQL_FUNCTION.format(
+                    activate_path=activate_path)
+                cursor.execute(sql)
+
+
+def main(argv=None):
+    """Set up python virtualenv on postgres database for the triggers."""
+    parser = create_parser('init_venv', description=__doc__)
+    args = parser.parse_args(argv)
+
+    settings = get_app_settings_from_arguments(args)
+    connection_string = settings[config.CONNECTION_STRING]
+
+    init_venv(connection_string)
+
+    return 0
+
+
+if __name__ == '__main__':
+    main()
+
+
+__all__ = (
+    'init_venv',
+    'main',
+)

--- a/cnxarchive/tests/scripts/test_init_venv.py
+++ b/cnxarchive/tests/scripts/test_init_venv.py
@@ -1,0 +1,85 @@
+# -*- coding: utf-8 -*-
+# ###
+# Copyright (c) 2013, Rice University
+# This software is subject to the provisions of the GNU Affero General
+# Public License version 3 (AGPLv3).
+# See LICENCE.txt for details.
+# ###
+import os
+import sys
+import unittest
+
+import psycopg2
+
+from .. import testing
+
+
+class InitVenvTestCase(unittest.TestCase):
+    fixture = testing.schema_fixture
+
+    def setUp(self):
+        self.fixture.setUp()
+
+    def tearDown(self):
+        self.fixture.tearDown()
+
+    @property
+    def target(self):
+        from ...scripts.init_venv import main
+        return main
+
+    @testing.db_connect
+    def test_success(self, cursor):
+        # drop schema venv
+        cursor.execute('DROP SCHEMA IF EXISTS venv CASCADE')
+        cursor.connection.commit()
+
+        self.target(argv=[testing.config_uri()])
+
+        # test copied from pyimport
+
+        target_name = 'cnxarchive.database'
+
+        # Import the module from current directory
+        import cnxarchive.database as target_source
+
+        # Remove current directory from sys.path
+        cwd = os.getcwd()
+        sys_path = sys.path
+        modified_path = [i for i in sys_path if i and i != cwd]
+        sys.path = modified_path
+        self.addCleanup(setattr, sys, 'path', sys_path)
+
+        # Remove all cnxarchive modules from sys.modules
+        sys_modules = sys.modules.copy()
+        self.addCleanup(sys.modules.update, sys_modules)
+        for module in sys.modules.keys():
+            if module.startswith('cnxarchive'):
+                del sys.modules[module]
+
+        # Import the installed version
+        import cnxarchive.database as target_installed
+
+        # Depending on whether "setup.py develop" or "setup.py install" is
+        # used, there are different expected directories and file paths.
+        targets = [target_source, target_installed]
+        expected_directories = [
+            os.path.abspath(os.path.dirname(target.__file__))
+            for target in targets]
+        expected_file_paths = [
+            target.__file__ for target in targets]
+
+        # Check the results of calling pyimport on cnxarchive.
+        cursor.execute("SELECT import, directory, file_path "
+                       "FROM pyimport(%s)", (target_name,))
+        import_, directory, file_path = cursor.fetchone()
+
+        self.assertEqual(import_, target_name)
+        self.assertIn(directory, expected_directories)
+        self.assertIn(file_path, expected_file_paths)
+
+    @testing.db_connect
+    def test_rerun(self, cursor):
+        # running init_venv multiple times shouldn't error
+        self.target(argv=[testing.config_uri()])
+        self.target(argv=[testing.config_uri()])

--- a/setup.py
+++ b/setup.py
@@ -44,6 +44,7 @@ setup(
     main = cnxarchive:main
     [console_scripts]
     cnx-archive-initdb = cnxarchive.scripts.initializedb:main
+    cnx-archive-init_venv = cnxarchive.scripts.init_venv:main
     cnx-archive-hits_counter = cnxarchive.scripts.hits_counter:main
     cnx-archive-inject_resource = cnxarchive.scripts.inject_resource:main
     cnx-archive-export_epub = cnxarchive.scripts.export_epub.main:main


### PR DESCRIPTION
The script is copied from
https://github.com/pumazi/cnx-db/blob/454ee6a67ae265ac5dc1010248b9f3f1c7fd1722/cnxdb/init/main.py

Once we use cnx-db in cnx-archive, this script can be removed.

---

This pull request includes commits from #447.