### PR TITLE
Move modulestates to schema initialization

### DIFF
--- a/cnxarchive/sql/schema/constants/manifest.json
+++ b/cnxarchive/sql/schema/constants/manifest.json
@@ -1,5 +1,6 @@
 [
     "licenses.sql",
+    "modulestates.sql",
     "roles.sql",
     "service-states.sql",
     "tags.sql"

--- a/cnxarchive/sql/schema/constants/modulestates.sql
+++ b/cnxarchive/sql/schema/constants/modulestates.sql
@@ -1,0 +1,8 @@
+INSERT INTO modulestates VALUES (0, 'unknown');
+INSERT INTO modulestates VALUES (1, 'current');
+INSERT INTO modulestates VALUES (4, 'obsolete');
+INSERT INTO modulestates VALUES (5, 'post-publication');
+INSERT INTO modulestates VALUES (6, 'processing');
+INSERT INTO modulestates VALUES (7, 'errored');
+
+SELECT pg_catalog.setval('modulestates_stateid_seq', 8, false);

--- a/cnxarchive/tests/test_database.py
+++ b/cnxarchive/tests/test_database.py
@@ -76,9 +76,6 @@ class MiscellaneousFunctionsTestCase(unittest.TestCase):
     @testing.db_connect
     def setUp(self, cursor):
         self.fixture.setUp()
-        cursor.execute("""\
-            INSERT INTO modulestates (stateid, statename) \
-            VALUES (1, 'current')""")
 
     def tearDown(self):
         self.fixture.tearDown()
@@ -1572,13 +1569,6 @@ class LegacyCompatTriggerTestCase(unittest.TestCase):
         cursor.execute("""\
 INSERT INTO abstracts (abstract) VALUES (' ') RETURNING abstractid""")
         self._abstract_id = cursor.fetchone()[0]
-        cursor.execute("""\
-INSERT INTO modulestates VALUES (0, 'unknown');
-INSERT INTO modulestates VALUES (1, 'current');
-INSERT INTO modulestates VALUES (4, 'obsolete');
-INSERT INTO modulestates VALUES (5, 'post-publication');
-INSERT INTO modulestates VALUES (6, 'processing');
-INSERT INTO modulestates VALUES (7, 'errored');""")
 
     def tearDown(self):
         self.fixture.tearDown()


### PR DESCRIPTION
Module states should really be part of the database initialization, it's
not data to be added later.  It is necessary for the application, so
moving it to ``cnxarchive/sql/schema/``.