### PR TITLE
Fix duplicate minor versions created by republish trigger

### DIFF
--- a/cnxarchive/database.py
+++ b/cnxarchive/database.py
@@ -311,7 +311,7 @@ def get_collections(module_ident, plpy):
         FROM trees c JOIN t ON (c.nodeid = t.parent)
         WHERE not c.nodeid = ANY(t.path)
     )
-    SELECT m.module_ident
+    SELECT DISTINCT m.module_ident
     FROM t JOIN latest_modules m ON (t.document = m.module_ident)
     WHERE t.parent IS NULL
     ''', ('integer',))

--- a/cnxarchive/tests/test_database.py
+++ b/cnxarchive/tests/test_database.py
@@ -1035,6 +1035,17 @@ ALTER TABLE modules DISABLE TRIGGER module_published""")
 
     @testing.db_connect
     def test_module(self, cursor):
+        # Create a fake collated tree for College Physics which contains the
+        # module that is going to have a new version
+        cursor.execute("""\
+INSERT INTO trees (parent_id, documentid, is_collated)
+    VALUES (NULL, 1, TRUE) RETURNING nodeid""")
+        nodeid = cursor.fetchone()[0]
+        cursor.execute("""\
+INSERT INTO trees (parent_id, documentid, is_collated)
+    VALUES (%s, 2, TRUE)""", (nodeid,))
+        cursor.connection.commit()
+
         cursor.execute('SELECT nodeid FROM trees WHERE documentid = 18')
         old_nodeid = cursor.fetchone()[0]
 


### PR DESCRIPTION
On legacy-cte-cnx-dev.cnx.org, when a user publishes a new version of a
page, the archive republish trigger should create a new minor version
for all the books that contain that page.  Instead of seeing one new
entry per book, there were two inserted into the modules table, with the
same minor version.

The reason is when we get the books that contain the page, the sql looks
in the trees table which may contain two trees for some books, one
collated, one not collated.  We end up getting the same book twice.

The solution is to use `SELECT DISTINCT` to make sure one book is only
republished once.