### PR TITLE
db migration to add venv support

### DIFF
--- a/cnxarchive/sql/migrations/20160824022713_add_venv_support.py
+++ b/cnxarchive/sql/migrations/20160824022713_add_venv_support.py
@@ -1,0 +1,64 @@
+# -*- coding: utf-8 -*-
+
+
+def up(cursor):
+    """Install venv schema and session_preload if in a virtualenv."""
+    import sys
+
+    if hasattr(sys, 'real_prefix'):
+        activate_path = os.path.join(
+            os.path.realpath(sys.prefix),
+            'bin/activate_this.py')
+        cursor.execute("SELECT current_database();")
+        db_name = cursor.fetchone()[0]
+
+        cursor.execute("""SELECT schema_name FROM
+                          information_schema.schemata
+                          WHERE schema_name = 'venv';""")
+        schema_exists = cursor.fetchall()
+
+        if not schema_exists:
+            cursor.execute("CREATE SCHEMA venv")
+            cursor.execute("ALTER DATABASE \"{}\" SET "
+                           "session_preload_libraries ="
+                           "'session_exec'".format(db_name))
+            cursor.execute("ALTER DATABASE \"{}\" SET "
+                           "session_exec.login_name = "
+                           "'venv.activate_venv'"
+                           .format(db_name))
+            sql = """CREATE FUNCTION venv.activate_venv()
+RETURNS void LANGUAGE plpythonu AS $_$
+import sys
+import os
+import site
+old_os_path = os.environ['PATH']
+os.environ['PATH'] = os.path.dirname(os.path.abspath('{activate_path}')) \
++ os.pathsep + old_os_path
+base = os.path.dirname(os.path.dirname(os.path.abspath('{activate_path}')))
+site_packages = os.path.join(base, 'lib', 'python%s' % sys.version[:3], \
+'site-packages')
+prev_sys_path = list(sys.path)
+site.addsitedir(site_packages)
+sys.real_prefix = sys.prefix
+sys.prefix = base
+# Move the added items to the front of the path:
+new_sys_path = []
+for item in list(sys.path):
+    if item not in prev_sys_path:
+        new_sys_path.append(item)
+        sys.path.remove(item)
+sys.path[:0] = new_sys_path
+$_$""".format(activate_path=activate_path)
+                        cursor.execute(sql)
+
+
+def down(cursor):
+    """Remove venvs schema and reset config."""
+    cursor.execute("SELECT current_database();")
+    db_name = cursor.fetchone()[0]
+
+    cursor.execute("ALTER DATABASE \"{}\" RESET "
+                   "session_preload_libraries".format(db_name))
+    cursor.execute("ALTER DATABASE \"{}\" RESET "
+                   "session_exec.login_name".format(db_name))
+    cursor.execute("DROP SCHEMA IF EXISTS venv CASCADE")

--- a/cnxarchive/sql/migrations/20160824022713_add_venv_support.py
+++ b/cnxarchive/sql/migrations/20160824022713_add_venv_support.py
@@ -1,9 +1,10 @@
 # -*- coding: utf-8 -*-
+import os
+import sys
 
 
 def up(cursor):
     """Install venv schema and session_preload if in a virtualenv."""
-    import sys
 
     if hasattr(sys, 'real_prefix'):
         activate_path = os.path.join(
@@ -31,7 +32,7 @@ RETURNS void LANGUAGE plpythonu AS $_$
 import sys
 import os
 import site
-old_os_path = os.environ['PATH']
+old_os_path = os.environ.get('PATH','')
 os.environ['PATH'] = os.path.dirname(os.path.abspath('{activate_path}')) \
 + os.pathsep + old_os_path
 base = os.path.dirname(os.path.dirname(os.path.abspath('{activate_path}')))
@@ -49,7 +50,7 @@ for item in list(sys.path):
         sys.path.remove(item)
 sys.path[:0] = new_sys_path
 $_$""".format(activate_path=activate_path)
-                        cursor.execute(sql)
+            cursor.execute(sql)
 
 
 def down(cursor):


### PR DESCRIPTION
After creating a new deploy, and pushing a copy of production data to it, we run into the problem that virtualenv support is only added during initdb when two conditions are met: archive is running inside a venv, and the db connection is local. Production does not meet these requirements, so the data-dump from there does not have the venv support in place. This migration is written to be idempotent, so it will install the venv activation code only if it's not already there. This should allow it to run against datadumps from production as well as from other venv based installs.