### PR TITLE
Collated search fixes

### DIFF
--- a/cnxarchive/sql/migrations/20160923184915_correct_uuid_index.py
+++ b/cnxarchive/sql/migrations/20160923184915_correct_uuid_index.py
@@ -1,0 +1,25 @@
+# -*- coding: utf-8 -*-
+
+
+def up(cursor):
+    # Create correct index, drop less useful one
+    cursor.execute("""
+    CREATE INDEX modules_uuid_txt_version_idx ON modules
+    (cast(uuid as text), module_version(major_version, minor_version));
+    CREATE INDEX latest_modules_uuid_txt_version_idx ON latest_modules
+    (cast(uuid as text), module_version(major_version, minor_version));
+    DROP INDEX modules_uuid_version_idx;
+    DROP INDEX latest_modules_uuid_version_idx;
+    """)
+
+
+def down(cursor):
+    # Drop correct index, create less useful one
+    cursor.execute("""
+    CREATE INDEX modules_uuid_version_idx ON modules
+    (uuid, module_version(major_version, minor_version));
+    CREATE INDEX latest_modules_uuid_version_idx ON latest_modules
+    (uuid, module_version(major_version, minor_version));
+    DROP INDEX modules_uuid_txt_version_idx;
+    DROP INDEX latest_modules_uuid_txt_version_idx;
+    """)

--- a/cnxarchive/sql/schema/fulltext-indexing.sql
+++ b/cnxarchive/sql/schema/fulltext-indexing.sql
@@ -139,7 +139,7 @@ CREATE OR REPLACE FUNCTION index_collated_fulltext_trigger()
     _baretext text;
     _idx_vectors tsvector;
   BEGIN
-    has_existing_record := (SELECT item, context FROM collated_fti WHERE item = NEW.item and context = NEW.context);
+    has_existing_record := (SELECT item FROM collated_fti WHERE item = NEW.item and context = NEW.context);
     _baretext := (SELECT xml_to_baretext(convert_from(f.file, 'UTF8')::xml)::text FROM files AS f WHERE f.fileid = NEW.fileid);
     _idx_vectors := to_tsvector(_baretext);
 
@@ -165,7 +165,7 @@ CREATE OR REPLACE FUNCTION index_collated_fulltext_lexeme_update_trigger()
   RETURNS TRIGGER AS $$
   BEGIN
 
-    DELETE from collated_fti_lexemes where item = NEW.item;
+    DELETE from collated_fti_lexemes where item = NEW.item AND context = NEW.context;
 
     INSERT into collated_fti_lexemes (item, context, lexeme, positions)
        (with lex as (SELECT regexp_split_to_table(NEW.module_idx::text, E' \'') as t )

--- a/cnxarchive/sql/schema/indexes.sql
+++ b/cnxarchive/sql/schema/indexes.sql
@@ -3,8 +3,8 @@ CREATE INDEX modules_upmodid_idx ON modules  (upper(moduleid));
 CREATE INDEX modules_upname_idx ON modules  (upper(name));
 CREATE INDEX modules_portal_type_idx on modules (portal_type);
 CREATE INDEX modules_uuid_idx on modules (uuid);
-CREATE INDEX modules_uuid_version_idx on
-    modules (uuid, module_version(major_version, minor_version));
+CREATE INDEX modules_uuid_txt_version_idx on
+    modules (CAST(uuid as text), module_version(major_version, minor_version));
 CREATE INDEX modules_short_id_idx on modules (short_id(uuid));
 
 CREATE INDEX latest_modules_upmodid_idx ON latest_modules  (upper(moduleid));
@@ -13,8 +13,8 @@ CREATE INDEX latest_modules_moduleid_idx on latest_modules (moduleid);
 CREATE INDEX latest_modules_module_ident_idx on latest_modules (module_ident);
 CREATE INDEX latest_modules_portal_type_idx on latest_modules (portal_type);
 CREATE UNIQUE INDEX lastest_modules_uuid_idx on latest_modules (uuid);
-CREATE INDEX latest_modules_uuid_version_idx on
-    latest_modules (uuid, module_version(major_version, minor_version));
+CREATE INDEX latest_modules_uuid_text_version_idx on
+    latest_modules (cast(uuid as text), module_version(major_version, minor_version));
 CREATE UNIQUE INDEX lastest_modules_short_id_idx on latest_modules (short_id(uuid));
 
 CREATE INDEX fti_idx ON modulefti USING gist (module_idx);

--- a/cnxarchive/tests/test_views.py
+++ b/cnxarchive/tests/test_views.py
@@ -121,6 +121,19 @@ COLLECTION_METADATA = {
                 },
             },
         {
+            u"version": u"6.2",
+            u"revised": u"2013-08-02T01:02:23Z",
+            u"changes": u"Add second collated version",
+            u"publisher": {
+                u"surname": None,
+                u"firstname": "OpenStax College",
+                u"suffix": None,
+                u"title": None,
+                u"id": "OpenStaxCollege",
+                u"fullname": "OpenStax College",
+                },
+            },
+        {
             u'version': u'6.1',
             u'revised': u'2013-07-31T19:07:20Z',
             u'changes': 'Updated something',

--- a/cnxarchive/tests/transforms/test_resolvers.py
+++ b/cnxarchive/tests/transforms/test_resolvers.py
@@ -133,7 +133,7 @@ class HtmlReferenceResolutionTestCase(unittest.TestCase):
         <a href="/contents/e79ffde3-7fb4-4af3-9ec8-df648b391597:d395b566-5fe3-4428-bcb2-19016e3aa3ce#figure">
             Module link with collection
         </a>
-        <a href="/contents/e79ffde3-7fb4-4af3-9ec8-df648b391597@6.1:209deb1f-1a46-4369-9e0d-18674cf58a3e">
+        <a href="/contents/e79ffde3-7fb4-4af3-9ec8-df648b391597@6.2:209deb1f-1a46-4369-9e0d-18674cf58a3e">
             Module link with collection and version
         </a>
         <img src="/resources/d47864c2ac77d80b1f2ff4c4c7f1b2059669e3e9/Figure_01_00_01.jpg"/>

--- a/cnxarchive/transforms/resolvers.py
+++ b/cnxarchive/transforms/resolvers.py
@@ -355,7 +355,7 @@ class CnxmlToHtmlReferenceResolver(BaseReferenceResolver):
         pages = list(flatten_tree_to_ident_hashes(tree))
         book_ident_hash = join_ident_hash(book_uuid, book_version)
         page_ident_hash = join_ident_hash(page_uuid, page_version)
-        for p_ident_hash in flatten_tree_to_ident_hashes(tree):
+        for p_ident_hash in pages:
             p_id, p_version = split_ident_hash(p_ident_hash)
             if (p_id == page_uuid and
                     (page_version is None or


### PR DESCRIPTION
Fixing two problems with collated search. First, the results where wrong - failed to limit the matches to the cooked version of the page that was in that specific book/context - this lead to bogus results as soon as I used it on a server with more than one cooked book using the same modules. Second, the new performance indices where not actually being used due to some typecasting. 
Includes tests, and a db migration