### PR TITLE
switch from coveralls to codecov

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ before_install:
   - cd rhaptos.cnxmlutils && python setup.py install && cd ..
   # Scripts get installed to /usr/local/bin
   - pip install coverage
-  - pip install coveralls
+  - pip install codecov
 install:
   - python setup.py install
 before_script:
@@ -48,7 +48,7 @@ script:
   # This is the same as `python -m unittest discover` with a coverage wrapper.
   - coverage run --source=cnxarchive setup.py test
 after_success:
-  # Report test coverage to coveralls.io
-  - coveralls
+  # Report test coverage to codecov.io
+  - codecov
 notifications:
   email: false

--- a/README.rst
+++ b/README.rst
@@ -191,8 +191,8 @@ Running tests
 .. image:: https://travis-ci.org/Connexions/cnx-archive.png?branch=master
    :target: https://travis-ci.org/Connexions/cnx-archive
 
-.. image:: https://coveralls.io/repos/Connexions/cnx-archive/badge.svg?branch=master&service=github
-   :target: https://coveralls.io/github/Connexions/cnx-archive?branch=master
+.. image:: https://img.shields.io/codecov/c/github/Connexions/cnx-archive.svg
+   :target: https://codecov.io/gh/Connexions/cnx-archive
 
 The tests use the standard library ``unittest`` package and can therefore
 be run with minimal effort. Make a testing config, such as testing.ini,


### PR DESCRIPTION
As part of https://github.com/openstax/napkin-notes/issues/68 this switches from coveralls to codecov.

I was not sure about a couple things but took some defaults:

- When should coveralls make comments on the PR and what should be included
- I used this recommendation from codecov.io: https://github.com/codecov/example-python
