### PR TITLE
Correctly assign subcollection (chapter) ids

### DIFF
--- a/cnxarchive/scripts/export_epub/modeling.py
+++ b/cnxarchive/scripts/export_epub/modeling.py
@@ -82,6 +82,10 @@ def tree_to_nodes(tree, context=None):
             for key in ('title', 'id', 'shortId'):
                 if item.get(key):
                     metadata[key] = item[key]
+                    if key == 'id':
+                        metadata['cnx-archive-uri'] = item[key]
+                    elif key == 'shortId':
+                        metadata['cnx-archive-shortid'] = item[key]
             if item.get('id') is not None:
                 tbinder = cnxepub.Binder(item.get('id'),
                                          sub_nodes,
@@ -113,6 +117,7 @@ def _type_to_factory(type):
     try:
         factory = {'Module': document_factory,
                    'Collection': binder_factory,
+                   'SubCollection': binder_factory,
                    }[type]
     except KeyError:  # pragma: no cover
         raise RuntimeError("unknown type: {}".format(type))

--- a/cnxarchive/scripts/export_epub/modeling.py
+++ b/cnxarchive/scripts/export_epub/modeling.py
@@ -82,10 +82,11 @@ def tree_to_nodes(tree, context=None):
             for key in ('title', 'id', 'shortId'):
                 if item.get(key):
                     metadata[key] = item[key]
-                    if key == 'id':
-                        metadata['cnx-archive-uri'] = item[key]
-                    elif key == 'shortId':
-                        metadata['cnx-archive-shortid'] = item[key]
+                    if item[key] != 'subcol':
+                        if key == 'id':
+                            metadata['cnx-archive-uri'] = item[key]
+                        elif key == 'shortId':
+                            metadata['cnx-archive-shortid'] = item[key]
             if item.get('id') is not None:
                 tbinder = cnxepub.Binder(item.get('id'),
                                          sub_nodes,

--- a/cnxarchive/tests/scripts/test_export_epub.py
+++ b/cnxarchive/tests/scripts/test_export_epub.py
@@ -515,8 +515,8 @@ class TreeToNodesTestCase(BaseTestCase):
                 {'id': '209deb1f-1a46-4369-9e0d-18674cf58a3e@7',
                  'shortId': None,
                  'title': '(title override)'},
-                {'id': 'subcol',
-                 'shortId': None,
+                {'id': 'd7eb0963-6cfa-57fe-8e18-585474e8b563@7.1',
+                 'shortId': '1-sJY2z6@7.1',
                  'title': None,
                  'contents': [
                      {'id': 'f3c9ab70-a916-4d8c-9256-42953287b4e9@3',


### PR DESCRIPTION
Because of the way published content was being parsed into a model,
the ids of a baked chapter's content was being set to the same
as the first page within the chapter. This fixes that.