### PR TITLE
Composite module and subcollection bugfix

### DIFF
--- a/cnxarchive/database.py
+++ b/cnxarchive/database.py
@@ -9,7 +9,6 @@
 import os
 import json
 import psycopg2
-import sys
 import logging
 
 import cnxdb
@@ -117,7 +116,6 @@ def get_tree(ident_hash, cursor, as_collated=False):
     except TypeError:  # NoneType
         raise ContentNotFound()
     if type(tree) in (type(''), type(u'')):
-        import json
         return json.loads(tree)
     else:
         return tree
@@ -461,11 +459,11 @@ FROM (
         if portal_type == 'Collection':
             args.append('collectionid_seq')
             args.append(4)
-            args.append(('Collection','SubCollection'))
+            args.append(('Collection', 'SubCollection'))
         elif portal_type == 'Module':
             args.append('moduleid_seq')
             args.append(2)
-            args.append(('Module','CompositeModule'))
+            args.append(('Module', 'CompositeModule'))
         args.append(moduleid)
         if len(args) == 4:
             plpy.execute(plan, args)

--- a/cnxarchive/database.py
+++ b/cnxarchive/database.py
@@ -454,17 +454,19 @@ def assign_moduleid_default_trigger(plpy, td):
         plan = plpy.prepare("""\
 SELECT setval($1, max(substr(moduleid, $2)::int))
 FROM (
-  SELECT moduleid from modules where portal_type = $3
+  SELECT moduleid from modules where portal_type in $3
   UNION ALL
   SELECT $4) AS all_together""", ['text', 'int', 'text', 'text'])
         args = []
         if portal_type == 'Collection':
             args.append('collectionid_seq')
             args.append(4)
+            args.append(('Collection','SubCollection'))
         elif portal_type == 'Module':
             args.append('moduleid_seq')
             args.append(2)
-        args.extend([portal_type, moduleid])
+            args.append(('Module','CompositeModule'))
+        args.append(moduleid)
         if len(args) == 4:
             plpy.execute(plan, args)
 

--- a/cnxarchive/database.py
+++ b/cnxarchive/database.py
@@ -452,18 +452,18 @@ def assign_moduleid_default_trigger(plpy, td):
         plan = plpy.prepare("""\
 SELECT setval($1, max(substr(moduleid, $2)::int))
 FROM (
-  SELECT moduleid from modules where portal_type in $3
+  SELECT moduleid from modules where portal_type in ($3,$4)
   UNION ALL
   SELECT $4) AS all_together""", ['text', 'int', 'text', 'text'])
         args = []
         if portal_type == 'Collection':
             args.append('collectionid_seq')
             args.append(4)
-            args.append(('Collection', 'SubCollection'))
+            args.extend(('Collection', 'SubCollection'))
         elif portal_type == 'Module':
             args.append('moduleid_seq')
             args.append(2)
-            args.append(('Module', 'CompositeModule'))
+            args.extend(('Module', 'CompositeModule'))
         args.append(moduleid)
         if len(args) == 4:
             plpy.execute(plan, args)

--- a/cnxarchive/utils/mimetype.py
+++ b/cnxarchive/utils/mimetype.py
@@ -29,7 +29,7 @@ PORTALTYPE_TO_MIMETYPE_MAPPING = {
     'Module': MODULE_MIMETYPE,
     'CompositeModule': COMPOSITE_MODULE_MIMETYPE,
     'Collection': COLLECTION_MIMETYPE,
-    'SubCollection': COLLECTION_MIMETYPE,
+    'SubCollection': SUBCOLLECTION_MIMETYPE,
     }
 
 


### PR DESCRIPTION
Publishing content with chapter ids from legacy was resetting the serial counters incorrectly, in the presence of subcollections and composite modules.