### PR TITLE
Fix to disallow special char and < 3 char searches

### DIFF
--- a/cnxarchive/search.py
+++ b/cnxarchive/search.py
@@ -37,6 +37,7 @@ with open(os.path.join(here, 'data', 'common-english-words.txt'), 'r') as f:
                  [chr(i) for i in range(ord('a'), ord('z') + 1)])
 WILDCARD_KEYWORD = 'text'
 VALID_FILTER_KEYWORDS = ('type', 'pubYear', 'authorID', 'submitterID')
+SEARCH_SPECIAL_CHARS = '"\',:'
 # The maximum number of keywords and authors to return in the search result
 # counts
 MAX_VALUES_FOR_KEYWORDS = 100

--- a/cnxarchive/tests/test_views.py
+++ b/cnxarchive/tests/test_views.py
@@ -2103,8 +2103,63 @@ INSERT INTO trees (nodeid, parent_id, title, childorder, is_collated)
                 },
             }))
 
+    def test_search_with_only_special_chars(self):
+        # Disallow searches that contain only special chars ["',:]
+        from ..search import SEARCH_SPECIAL_CHARS
+        self.request.params = {'q': SEARCH_SPECIAL_CHARS}
+        self.request.matched_route = mock.Mock()
+        self.request.matched_route.name = 'search'
+
+        from ..views import search
+        results = search(self.request).body
+        status = self.request.response.status
+        content_type = self.request.response.content_type
+
+        self.assertEqual(status, '200 OK')
+        self.assertEqual(content_type, 'application/json')
+
+        self.assertEqual(results, json.dumps({
+            u'query': {
+                u'limits': [],
+                u'per_page': 20,
+                u'page': 1,
+                },
+            u'results': {
+                u'items': [],
+                u'total': 0,
+                u'limits': [],
+                },
+            }))
+
+    def test_search_less_than_three_chars(self):
+        # Disallow searches that contain only special chars ["',:]
+        self.request.params = {'q': 'at'}
+        self.request.matched_route = mock.Mock()
+        self.request.matched_route.name = 'search'
+
+        from ..views import search
+        results = search(self.request).body
+        status = self.request.response.status
+        content_type = self.request.response.content_type
+
+        self.assertEqual(status, '200 OK')
+        self.assertEqual(content_type, 'application/json')
+
+        self.assertEqual(results, json.dumps({
+            u'query': {
+                u'limits': [],
+                u'per_page': 20,
+                u'page': 1,
+                },
+            u'results': {
+                u'items': [],
+                u'total': 0,
+                u'limits': [],
+                },
+            }))
+
     def test_search_utf8(self):
-        self.request.params = {'q': '"你好"'}
+        self.request.params = {'q': '"今天你好吗"'}
         self.request.matched_route = mock.Mock()
         self.request.matched_route.name = 'search'
 
@@ -2118,7 +2173,7 @@ INSERT INTO trees (nodeid, parent_id, title, childorder, is_collated)
 
         expected = {
             u'query': {
-                u'limits': [{u'tag': u'text', u'value': u'你好'}],
+                u'limits': [{u'tag': u'text', u'value': u'今天你好吗'}],
                 u'sort': [],
                 u'per_page': 20,
                 u'page': 1,

--- a/cnxarchive/views.py
+++ b/cnxarchive/views.py
@@ -28,7 +28,7 @@ from . import cache
 from . import database
 from .database import SQL, get_tree, get_collated_content
 from .search import (
-    DEFAULT_PER_PAGE, QUERY_TYPES, DEFAULT_QUERY_TYPE,
+    DEFAULT_PER_PAGE, QUERY_TYPES, DEFAULT_QUERY_TYPE, SEARCH_SPECIAL_CHARS,
     Query,
     )
 from .sitemap import Sitemap
@@ -780,6 +780,11 @@ def search(request):
         page = None
     if page is None or page <= 0:
         page = 1
+
+    stripped_search_terms = search_terms.strip(SEARCH_SPECIAL_CHARS)
+    if (not stripped_search_terms) or (len(stripped_search_terms) < 3):
+        resp.body = empty_response
+        return resp
 
     query = Query.from_raw_query(search_terms)
     if not(query.filters or query.terms):


### PR DESCRIPTION
It's not exactly pretty, but it should work. The search view is a mess, so adding this condition to that mess isn't going to make it that much worse. 😛 