### PR TITLE
Oai feed

### DIFF
--- a/cnxarchive/__init__.py
+++ b/cnxarchive/__init__.py
@@ -72,6 +72,7 @@ def declare_api_routes(config):
     add_route('legacy-redirect-latest', '/content/{objid}/latest{ignore:(/)?}{filename:(.+)?}')  # noqa cnxarchive.views:redirect_legacy_content
     add_route('legacy-redirect-w-version', '/content/{objid}/{objver}{ignore:(/)?}{filename:(.+)?}')  # noqa cnxarchive.views:redirect_legacy_content
     add_route('recent', '/feeds/recent.rss')  # cnxarchive.views:recent
+    add_route('oai', '/feeds/oai')  # cnxarchive.views:oai
 
 
 def declare_type_info(config):
@@ -98,9 +99,10 @@ def main(global_config, **settings):
     declare_api_routes(config)
     declare_type_info(config)
 
-    # allowing the pyramid templates to render rss
+    # allowing the pyramid templates to render rss and xml
     config.include('pyramid_jinja2')
     config.add_jinja2_renderer('.rss')
+    config.add_jinja2_renderer('.xml')
 
     mandatory_settings = ['exports-directories', 'exports-allowable-types',
                           'sitemap-destination']

--- a/cnxarchive/config.py
+++ b/cnxarchive/config.py
@@ -17,3 +17,4 @@ CONNECTION_STRING = 'db-connection-string'
 here = os.path.abspath(os.path.dirname(__file__))
 TEST_DATA_DIRECTORY = os.path.join(here, 'tests', 'data')
 TEST_DATA_SQL_FILE = os.path.join(TEST_DATA_DIRECTORY, 'data.sql')
+REPOSITORY_NAME = 'OpenStax-CNX Repository'

--- a/cnxarchive/oai.py
+++ b/cnxarchive/oai.py
@@ -1,0 +1,267 @@
+# -*- coding: utf-8 -*-
+# ###
+# Copyright (c) 2013, Rice University
+# This software is subject to the provisions of the GNU Affero General
+# Public License version 3 (AGPLv3).
+# See LICENCE.txt for details.
+# ###
+import os
+import json
+import logging
+from datetime import datetime, timedelta
+from re import compile, match
+
+import psycopg2
+import psycopg2.extras
+from pyramid import httpexceptions
+from pyramid.settings import asbool
+from pyramid.threadlocal import get_current_registry, get_current_request
+from pyramid.view import view_config
+
+from . import config
+from . import cache
+from . import database
+from .search import (
+    DEFAULT_PER_PAGE, QUERY_TYPES, DEFAULT_QUERY_TYPE, DEFAULT_SEARCH_WEIGHTS,
+    Query, _build_search, QueryResults
+    )
+from .views import html_rss_date
+
+# ################### #
+#     OAI HELPERS     #
+# ################### #
+
+
+def _setFromUntil(request):
+    arguments = []
+    where = ""
+    if 'from' in request.GET.keys():
+        where = "WHERE revised>=(%s)"
+        arguments.append(request.GET.get('from'))
+    if 'until' in request.GET.keys():
+        arguments.append(request.GET.get('until'))
+        if where == "":
+            where = "WHERE revised<=(%s)"
+        else:
+            where += " AND revised<=(%s)"
+    return where, arguments
+
+
+def _databaseDictResults(statement, arguments, settings):
+    with psycopg2.connect(settings[config.CONNECTION_STRING]) as db_c:
+        cur = db_c.cursor(cursor_factory=psycopg2.extras.DictCursor)
+        cur.execute(statement, vars=arguments)
+        search_results = cur.fetchall()
+    return search_results
+
+
+def _parseOaiArguments(verb, request):
+    VERBS = {'GetRecord': {'required': ['verb', 'identifier',
+                                        'metadataPrefix'],
+                           'optional': []},
+             'Identify': {'required': ['verb'],
+                          'optional': []},
+             'ListIdentifiers': {'required': ['verb', 'metadataPrefix'],
+                                 'optional': ['from', 'until', 'set']},
+             'ListMetadataFormats': {'required': ['verb'],
+                                     'optional': ['identifier']},
+             'ListRecords': {'required': ['verb', 'metadataPrefix'],
+                             'optional': ['from', 'until', 'set']},
+             'ListSets': {'required': ['verb'],
+                          'optional': ['resumptionToken']},
+             }
+    # verify that the arguments given are correct, otherwise set an error
+    if not(verb in VERBS.keys()):
+        return {'code': 'badVerb',
+                'message': 'Illegal verb: Legal verbs are: {}'.
+                           format(VERBS.keys())}
+    # check to make sure only correct arguments have been passed
+    all_query_vars = request.GET.keys()
+    required = VERBS[verb]['required']
+    optional = VERBS[verb]['optional']
+    missing = list(set(required) - set(all_query_vars))
+    if missing:
+        return {'code': 'badArgument',
+                'message': 'Required argument {} missing'.format(missing)}
+    extras = list(set(all_query_vars) - (set(required) | set(optional)))
+    if extras:
+        return {'code': 'badArgument',
+                'message': 'Illegal arguments: {}'. format(extras)}
+    return "No errors"
+
+
+def _verifyMetadataPrefix(request):
+    prefixes = ['oai_dc', 'ims1_2_1', 'cnx_dc']
+    prefix = request.GET.get('metadataPrefix')
+    if prefix not in prefixes:
+        return {'error': {'code': 'cannotDisseminateFormat',
+                          'message': 'metadataPrefix {} not supported'.
+                                     format(prefix)}}
+    return {'metadataPrefix': prefix}
+
+
+def _noRecordsMatchError():
+    return {'error': {'code': 'noRecordsMatch',
+                      'message': 'No matches for the given request'}}
+
+
+def _formatOaiResults(results, request):
+    if len(results) == 0:
+        return _noRecordsMatchError()
+    for result in results:
+        result['uuid'] = 'oai:{}:{}'.format(request.host, result['uuid'])
+        new_authors = []
+        for i in range(len(result['authors'])):
+            new_authors.append({'fullname': result['authors'][i],
+                                'email': result['author_emails'][i]})
+        result['authors'] = new_authors
+    return {'results': results}
+
+
+def _oaiGetBaseStatement():
+    return """
+             name, created, revised, uuid, portal_type, language,
+             concat(major_version, '.', minor_version) as version,
+             ARRAY(SELECT k.word FROM keywords as k, modulekeywords
+                as mk WHERE mk.module_ident = lm.module_ident AND
+                    mk.keywordid = k.keywordid) as keywords,
+             ARRAY(SELECT tags.tag FROM tags, moduletags
+                as mt WHERE mt.module_ident = lm.module_ident AND
+                    mt.tagid = tags.tagid) as subjects,
+             ARRAY(SELECT fullname as fields FROM persons WHERE
+                persons.personid = ANY (lm.authors)) as authors,
+             ARRAY(SELECT email as fields FROM persons WHERE
+                persons.personid = ANY (lm.authors)) as author_emails,
+             ARRAY(SELECT fullname FROM persons WHERE persons.personid =
+                ANY (lm.maintainers)) as maintainers,
+             ARRAY(SELECT fullname FROM persons WHERE exists
+                (SELECT true FROM moduleoptionalroles as mor
+                    JOIN roles as r ON mor.roleid=r.roleid
+                        WHERE mor.module_ident = lm.module_ident AND
+                        r.roleparam='translator' AND
+                        persons.personid = ANY (mor.personids)))
+                as translators,
+             (COALESCE((SELECT abstract FROM abstracts WHERE
+                lm.abstractid = abstracts.abstractid), '')) as abstract,
+             (SELECT url FROM licenses
+                WHERE lm.licenseid = licenses.licenseid) as licenses_url
+                           """
+
+
+def do_Identify(request):
+    return {'host': request.host,
+            'adminEmail': "support@openstax.org",
+            'repository': config.REPOSITORY_NAME}
+
+
+def do_ListMetadataFormats(request):
+    METADATA_FORMATS = [
+        {'prefix': 'oai_dc',
+         'schema': 'http://www.openarchives.org/OAI/2.0/oai_dc.xsd',
+         'namespace': 'http://www.openarchives.org/OAI/2.0/oai_dc/'},
+        {'prefix': 'ims1_2_1',
+         'schema': 'http://www.imsglobal.org/xsd/imsmd_v1p2p4.xsd',
+         'namespace': 'http://www.imsglobal.org/xsd/imsmd_v1p2'},
+        {'prefix': 'cnx_dc',
+         'schema': '/http://cnx.rice.edu/technology/cnx_dc/schema/xsd/1.0/'
+                   'cnx-dc-extension.xsd',
+         'namespace': 'http://cnx.rice.edu/cnx_dc/'}
+        ]
+    return {'results': METADATA_FORMATS}
+
+
+def do_ListSets(request):
+    # return error, ListSets currently not supported
+    return {'error': {'code': 'noSetHierarchy',
+                      'message': 'ListSets not currently supported'}}
+
+
+def do_ListIdentifiers(request):
+    new_vars = _verifyMetadataPrefix(request)
+    if 'error' in new_vars.keys():
+        return new_vars
+    where, arguments = _setFromUntil(request)
+    statement = """
+                SELECT revised, uuid
+                FROM latest_modules {}
+                ORDER BY revised;
+                """.format(where)
+    settings = request.registry.settings
+    search_results = _databaseDictResults(statement, arguments, settings)
+    if len(search_results) == 0:
+        return _noRecordsMatchError()
+    new_vars.update({'results': search_results})
+    return new_vars
+
+
+def do_GetRecords(request):
+    new_vars = _verifyMetadataPrefix(request)
+    if 'error' in new_vars.keys():
+        return new_vars
+    identifier = str(request.GET.get('identifier'))
+    idDoesNotExist = {'code': 'idDoesNotExist',
+                      'message': "id does not exist {}".
+                                 format(identifier)}
+    pattern = ("oai:" + request.host + ":[0-9a-z]{8}-[0-9a-z]{4}-"
+               "[0-9a-z]{4}-[0-9a-z]{4}-[0-9a-z]{12}$")
+    if not compile(pattern).match(identifier):
+        return {'error': idDoesNotExist}
+    uuid = identifier.split(':')[-1]
+    statement = "SELECT" + _oaiGetBaseStatement()
+    statement += "FROM latest_modules as lm  WHERE uuid=(%s);"
+    settings = request.registry.settings
+    results = _databaseDictResults(statement, (uuid,), settings)
+    if len(results) == 0:
+        return {'error': idDoesNotExist}
+    new_vars.update(_formatOaiResults(results, request))
+    return new_vars
+
+
+def do_ListRecords(request):
+    new_vars = _verifyMetadataPrefix(request)
+    if 'error' in new_vars.keys():
+        return new_vars
+    where, arguments = _setFromUntil(request)
+    statement = "SELECT" + _oaiGetBaseStatement()
+    statement += "FROM latest_modules as lm {} ORDER BY revised;".format(where)
+    settings = request.registry.settings
+    results = _databaseDictResults(statement, arguments, settings)
+    new_vars.update(_formatOaiResults(results, request))
+    return new_vars
+
+
+# ################## #
+#      OAI VIEW      #
+# ################## #
+
+
+@view_config(route_name='oai', request_method='GET',
+             renderer='templates/oai_verbs.xml')
+def oai(request):
+    request.response.headers = {'Content-Type': 'text/xml; charset=UTF-8'}
+
+    return_vars = {}
+    return_vars['dateTime'] = html_rss_date(datetime.now().time())
+    return_vars['baseURL'] = request.path_url
+    return_vars['query_request'] = []
+    for var in request.GET:
+        return_vars['query_request'].append({'name': var,
+                                             'val': request.GET[var]})
+
+    verb = request.GET.get('verb')
+    parse_results = _parseOaiArguments(verb, request)
+    return_vars['verb'] = verb
+    if parse_results != "No errors":
+        return_vars['error'] = parse_results
+        return return_vars
+
+    oaiQuery = {'Identify': do_Identify(request),
+                'ListMetadataFormats': do_ListMetadataFormats(request),
+                'ListSets': do_ListSets(request),
+                'ListIdentifiers': do_ListIdentifiers(request),
+                'GetRecord': do_GetRecords(request),
+                'ListRecords': do_ListRecords(request)}
+
+    return_vars.update(oaiQuery[verb])
+
+    return return_vars

--- a/cnxarchive/oai.py
+++ b/cnxarchive/oai.py
@@ -115,7 +115,7 @@ def _formatOaiResults(results, request):
         result['maintainers'] = _decodeArray(result['maintainers'])
         result['translators'] = _decodeArray(result['translators'])
         result['link'] = request.route_url('content',
-                                   ident_hash=result['link'])
+                                           ident_hash=result['link'])
         new_authors = []
         for i in range(len(result['authors'])):
             new_authors.append({'fullname': result['authors'][i],

--- a/cnxarchive/oai.py
+++ b/cnxarchive/oai.py
@@ -130,6 +130,7 @@ def _decodeArray(result_array):
         decoded.append(result.decode('utf-8'))
     return decoded
 
+
 def _oaiGetBaseStatement():
     return """
              name, created, revised, uuid, uuid as link, portal_type, language,

--- a/cnxarchive/oai.py
+++ b/cnxarchive/oai.py
@@ -115,7 +115,7 @@ def _formatOaiResults(results, request):
         result['maintainers'] = _decodeArray(result['maintainers'])
         result['translators'] = _decodeArray(result['translators'])
         result['link'] = request.route_url('content',
-                                   ident_hash=result['uuid'])
+                                   ident_hash=result['link'])
         new_authors = []
         for i in range(len(result['authors'])):
             new_authors.append({'fullname': result['authors'][i],

--- a/cnxarchive/oai.py
+++ b/cnxarchive/oai.py
@@ -114,8 +114,8 @@ def _formatOaiResults(results, request):
         result['authors'] = _decodeArray(result['authors'])
         result['maintainers'] = _decodeArray(result['maintainers'])
         result['translators'] = _decodeArray(result['translators'])
-        result['link'] = "{}/content/{}".format(request.host_url,
-                                                result['uuid'])
+        result['link'] = request.route_url('content',
+                                   ident_hash=result['uuid'])
         new_authors = []
         for i in range(len(result['authors'])):
             new_authors.append({'fullname': result['authors'][i],

--- a/cnxarchive/oai.py
+++ b/cnxarchive/oai.py
@@ -109,6 +109,11 @@ def _formatOaiResults(results, request):
     if len(results) == 0:
         return _noRecordsMatchError()
     for result in results:
+        result['name'] = result['name'].decode('utf-8')
+        result['abstract'] = result['abstract'].decode('utf-8')
+        result['authors'] = _decodeArray(result['authors'])
+        result['maintainers'] = _decodeArray(result['maintainers'])
+        result['translators'] = _decodeArray(result['translators'])
         result['link'] = "{}/content/{}".format(request.host_url,
                                                 result['uuid'])
         new_authors = []
@@ -118,6 +123,12 @@ def _formatOaiResults(results, request):
         result['authors'] = new_authors
     return {'results': results}
 
+
+def _decodeArray(result_array):
+    decoded = []
+    for result in result_array:
+        decoded.append(result.decode('utf-8'))
+    return decoded
 
 def _oaiGetBaseStatement():
     return """

--- a/cnxarchive/templates/oai_template.xml
+++ b/cnxarchive/templates/oai_template.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<OAI-PMH xmlns="http://www.openarchives.org/OAI/2.0/"
+         xmlns:tal="http://xml.zope.org/namespaces/tal"
+         xmlns:metal="http://xml.zope.org/namespaces/metal"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/
+                             http://www.openarchives.org/OAI/2.0/OAI-PMH.xsd">
+  <responseDate>{{dateTime}}</responseDate>
+  <request
+    {% for var in query_request %}
+      {{var.name}}="{{var.val}}"
+    {% endfor %}
+  >{{baseURL}}</request>
+
+  {% if error %}
+    <error code="{{error.code}}">{{error.message}}</error>
+  {% endif %}
+
+  {% if verb == 'Identify' %}
+    <Identify>
+      {% block identify %}
+      {% endblock %}
+    </Identify>
+  {% endif %}
+
+  {% if verb == 'GetRecord' %}
+    <GetRecord>
+      {% block records %}
+      {% endblock %}
+    </GetRecord>
+  {% endif %}
+
+  {% if verb == 'ListMetadataFormats' %}
+    <ListMetadataFormats>
+      {% block listMetadataFormats %}
+      {% endblock %}
+    </ListMetadataFormats>
+  {% endif %}
+
+  {% if verb == 'ListIdentifiers' %}
+    <ListIdentifiers>
+      {% block listIdentifiers %}
+      {% endblock %}
+    </ListIdentifiers>
+  {% endif %}
+
+  {% if verb == 'ListRecords' or verb == 'SearchRecords' %}
+    <ListRecords>
+      {{self.records()}}
+    </ListRecords>
+  {% endif %}
+
+</OAI-PMH>

--- a/cnxarchive/templates/oai_verbs.xml
+++ b/cnxarchive/templates/oai_verbs.xml
@@ -38,7 +38,7 @@
         <identifier>oai:/{{host}}:{{result.uuid}}</identifier>
         <datestamp>{{result.revised}}</datestamp>
       </header>
-    <headers>
+    </headers>
   {% endfor %}
 {% endblock %}
 

--- a/cnxarchive/templates/oai_verbs.xml
+++ b/cnxarchive/templates/oai_verbs.xml
@@ -1,0 +1,213 @@
+{% extends "oai_template.xml" %}
+
+{% block identify %}
+  <repositoryName>{{repository}}</repositoryName>
+  <baseURL>{{baseURL}}</baseURL>
+  <protocolVersion>2.0</protocolVersion>
+  <adminEmail>{{adminEmail}}</adminEmail>
+  <earliestDatestamp>2000-03-07 00:00:00Z</earliestDatestamp>
+  <deletedRecord>no</deletedRecord>
+  <granularity>YYYY-MM-DDThh:mm:ssZ</granularity>
+  <description>
+    <oai-identifier xmlns="http://www.openarchives.org/OAI/2.0/oai-identifier"
+                    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                    xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/oai-identifier
+                    http://www.openarchives.org/OAI/2.0/oai-identifier.xsd">
+      <scheme>oai</scheme>
+      <repositoryIdentifier>{{host}}</repositoryIdentifier>
+      <delimiter>:</delimiter>
+      <sampleIdentifier>oai:{{host}}:m0000</sampleIdentifier>
+    </oai-identifier>
+  </description>
+{% endblock %}
+
+{% block listMetadataFormats %}
+  {% for result in results %}
+    <metadataFormat>
+      <metadataPrefix>{{result.prefix}}</metadataPrefix>
+      <schema>{{result.schema}}</schema>
+      <metadataNamespace>{{result.namespace}}</metadataNamespace>
+    </metadataFormat>
+  {% endfor %}
+{% endblock %}
+
+{% block listIdentifiers %}
+  {% for result in results %}
+    <headers>
+      <header tal:condition="r/harvestable | string:True">
+        <identifier>oai:{{host}}/{{result.uuid}}</identifier>
+        <datestamp>{{result.revised}}</datestamp>
+      </header>
+    <headers>
+  {% endfor %}
+{% endblock %}
+
+{% block records %}
+  {% for record in results %}
+    <record>
+      <header>
+        <identifier>{{record.uuid}}</identifier>
+        <datestamp>{{record.revised}}</datestamp>
+      </header>
+      <metadata>
+        {% if metadataPrefix == "oai_dc" %}
+          <oai_dc:dc xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/"
+                           xmlns:dc="http://purl.org/dc/elements/1.1/"
+                           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                           xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/oai_dc/
+                           http://www.openarchives.org/OAI/2.0/oai_dc.xsd">
+            <dc:title>{{record.title}}</dc:title>
+            {% for author in record.authors %} <dc:creator>{{author.fullname}}</dc:creator> {% endfor %}
+            {% for subject in record.subjects %} <dc:subject>{{subject}}</dc:subject> {% endfor %}
+            <dc:description>{{record.abstract}}</dc:description>
+            <dc:language>{{record.language}}</dc:language>
+            <dc:date>{{record.revised}}</dc:date>
+            <dc:identifier>{{baseURL}}/{{record.uuid}}</dc:identifier>
+            <dc:rights>{{record.licenses_url}}</dc:rights>
+          </oai_dc:dc>
+        {% endif %}
+
+        {% if metadataPrefix == "cnx_dc" %}
+          <cnxdc:dc xmlns:cnxdc="http://cnx.org/technology/schemas/cnx_dc/"
+                           xmlns:dc="http://purl.org/dc/elements/1.1/"
+                           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                           xsi:schemaLocation="http://cnx.rice.edu/cnx_dc/
+                           http://cnx.rice.edu/technology/cnx_dc/schema/xsd/1.0/cnx-dc-extension.xsd">
+            <dc:title>{{record.title}}</dc:title>
+            {% for author in record.authors %} <dc:creator>{{author.fullname}}</dc:creator> {% endfor %}
+            {% for maintainer in record.maintainers %} <cnxdc:maintainer>{{maintainer}}</cnxdc:maintainer> {% endfor %}
+            {% for translator in record.translator %} <cnxdc:translator>{{translator}}</cnxdc:translator> {% endfor %}
+            {% for sponsor in record.sponsor %} <cnxdc:sponsor>{{sponsor}}</cnxdc:sponsor> {% endfor %}
+            {% for sponsor in record.funders %} <cnxdc:funders>{{funders}}</cnxdc:funders> {% endfor %}
+            {% for cnx_subject in record.subjects %} <cnxdc:subject>{{cnx_subject}}</cnxdc:subject> {% endfor %}
+            {% for subject in record.subjects %} <dc:subject>{{subject}}</dc:subject> {% endfor %}
+            <dc:description>{{record.abstract}}</dc:description>
+            <dc:language>{{record.language}}</dc:language>
+            <dc:date>{{record.revised}}</dc:date>
+            <dc:identifier>{{baseURL}}/{{record.uuid}}</dc:identifier>
+            <dc:rights>{{record.licenses_url}}</dc:rights>
+          </cnxdc:dc>
+        {% endif %}
+
+        {% if metadataPrefix == "ims1_2_1" %}
+          <ims1_2_1:lom xmlns:ims1_2_1="http://www.imsglobal.org/xsd/imsmd_v1p2"
+                           xsi:schemaLocation="http://www.imsglobal.org/xsd/imsmd_v1p2
+                           http://www.imsglobal.org/xsd/imsmd_v1p2p4.xsd">
+            <ims1_2_1:general>
+              <ims1_2_1:title>
+                <ims1_2_1:langstring xml:lang="{{record.language}}">{{record.title}}</ims1_2_1:langstring>
+              </ims1_2_1:title>
+              <ims1_2_1:language>{{record.language}}</ims1_2_1:language>
+              <ims1_2_1:description>
+                <ims1_2_1:langstring xml:lang="{{record.language}}">{{record.abstract}}</ims1_2_1:langstring>
+              </ims1_2_1:description>
+              {% for keyword in record.keywords %}
+                <ims1_2_1:keyword>
+                  <ims1_2_1:langstring xml:lang="{{record.language}}">{{record.keyword}}</ims1_2_1:langstring>
+                </ims1_2_1:keyword>
+              {% endfor %}
+              <ims1_2_1:structure>
+                <ims1_2_1:source>
+                  <ims1_2_1:langstring xml:lang="x-none">LOMv1.0</ims1_2_1:langstring>
+                </ims1_2_1:source>
+                <ims1_2_1:value>
+                  <ims1_2_1:langstring xml:lang="x-none">Mixed</ims1_2_1:langstring>
+                </ims1_2_1:value>
+              </ims1_2_1:structure>
+              <ims1_2_1:aggregationlevel>
+                <ims1_2_1:source>
+                  <ims1_2_1:langstring xml:lang="x-none">LOMv1.0</ims1_2_1:langstring>
+                </ims1_2_1:source>
+                {% if record.portal_type == 'Module' %}
+                  <ims1_2_1:value >
+                    <ims1_2_1:langstring xml:lang="x-none">2</ims1_2_1:langstring>
+                  </ims1_2_1:value>
+                {% endif %}
+                {% if record.portal_type == 'Collection'%}
+                  <ims1_2_1:value>
+                    <ims1_2_1:langstring xml:lang="x-none">3</ims1_2_1:langstring>
+                  </ims1_2_1:value>
+                {% endif %}
+              </ims1_2_1:aggregationlevel>
+            </ims1_2_1:general>
+            <ims1_2_1:lifecycle>
+              <ims1_2_1:version>
+                <ims1_2_1:langstring xml:lang="x-none">{{record.version}}</ims1_2_1:langstring>
+              </ims1_2_1:version>
+              <ims1_2_1:contribute>
+                <ims1_2_1:role>
+                  <ims1_2_1:source>
+                    <ims1_2_1:langstring xml:lang="x-none">LOMv1.0</ims1_2_1:langstring>
+                  </ims1_2_1:source>
+                  <ims1_2_1:value>
+                    <ims1_2_1:langstring xml:lang="x-none">Author</ims1_2_1:langstring>
+                  </ims1_2_1:value>
+                </ims1_2_1:role>
+                {% for author in record.authors %}
+                  <ims1_2_1:centity>
+                    <ims1_2_1:vcard>
+                      BEGIN:vCard FN:{{author.fullname}} EMAIL;INTERNET:{{author.email}} END:vCard
+                    </ims1_2_1:vcard>
+                  </ims1_2_1:centity>
+                {% endfor %}
+                <ims1_2_1:date>
+                  <ims1_2_1:datetime>{{record.revised}}</ims1_2_1:datetime>
+                </ims1_2_1:date>
+              </ims1_2_1:contribute>
+            </ims1_2_1:lifecycle>
+            <ims1_2_1:technical>
+              <ims1_2_1:format>text/html</ims1_2_1:format>
+              <ims1_2_1:location type="URI">http://cnx.org/contents/{{record.uuid}}@</ims1_2_1:location>
+              <ims1_2_1:requirement>
+                <ims1_2_1:type>
+                  <ims1_2_1:source>
+                    <ims1_2_1:langstring xml:lang="x-none">LOMv1.0</ims1_2_1:langstring>
+                  </ims1_2_1:source>
+                  <ims1_2_1:value>
+                    <ims1_2_1:langstring xml:lang="x-none">Browser</ims1_2_1:langstring>
+                  </ims1_2_1:value>
+                </ims1_2_1:type>
+                <ims1_2_1:name>
+                  <ims1_2_1:source>
+                    <ims1_2_1:langstring xml:lang="x-none">LOMv1.0</ims1_2_1:langstring>
+                  </ims1_2_1:source>
+                  <ims1_2_1:value>
+                    <ims1_2_1:langstring xml:lang="x-none">Any</ims1_2_1:langstring>
+                  </ims1_2_1:value>
+                </ims1_2_1:name>
+              </ims1_2_1:requirement>
+            </ims1_2_1:technical>
+            <ims1_2_1:rights>
+              <ims1_2_1:copyrightandotherrestrictions>
+                <ims1_2_1:source>
+                  <ims1_2_1:langstring xml:lang="x-none">LOMv1.0</ims1_2_1:langstring>
+                </ims1_2_1:source>
+                <ims1_2_1:value>
+                  <ims1_2_1:langstring xml:lang="x-none">yes</ims1_2_1:langstring>
+                </ims1_2_1:value>
+              </ims1_2_1:copyrightandotherrestrictions>
+              <ims1_2_1:description>
+                <ims1_2_1:langstring xml:lang="en">{{record.licenses_url}}</ims1_2_1:langstring>
+              </ims1_2_1:description>
+            </ims1_2_1:rights>
+            {% for subject in record.subjects %}
+              <ims1_2_1:classification>
+                <ims1_2_1:purpose>
+                  <ims1_2_1:source>
+                    <ims1_2_1:langstring xml:lang="x-none">LOMv1.0</ims1_2_1:langstring>
+                  </ims1_2_1:source>
+                  <ims1_2_1:value>
+                    <ims1_2_1:langstring xml:lang="x-none">Discipline</ims1_2_1:langstring>
+                  </ims1_2_1:value>
+                </ims1_2_1:purpose>
+                <ims1_2_1:keyword>
+                  <ims1_2_1:langstring xml:lang="en">{{subject}}</ims1_2_1:langstring>
+                </ims1_2_1:keyword>
+              </ims1_2_1:classification>
+            {% endfor %}
+          </ims1_2_1:lom>
+        {% endif %}
+      </metadata>
+    </record>
+  {% endfor %}
+{% endblock %}

--- a/cnxarchive/templates/oai_verbs.xml
+++ b/cnxarchive/templates/oai_verbs.xml
@@ -35,7 +35,7 @@
   {% for result in results %}
     <headers>
       <header tal:condition="r/harvestable | string:True">
-        <identifier>oai:{{host}}/{{result.uuid}}</identifier>
+        <identifier>oai:/{{host}}:{{result.uuid}}</identifier>
         <datestamp>{{result.revised}}</datestamp>
       </header>
     <headers>
@@ -46,7 +46,7 @@
   {% for record in results %}
     <record>
       <header>
-        <identifier>{{record.uuid}}</identifier>
+        <identifier>oai:/{{host}}:{{record.uuid}}</identifier>
         <datestamp>{{record.revised}}</datestamp>
       </header>
       <metadata>
@@ -62,7 +62,7 @@
             <dc:description>{{record.abstract}}</dc:description>
             <dc:language>{{record.language}}</dc:language>
             <dc:date>{{record.revised}}</dc:date>
-            <dc:identifier>{{baseURL}}/{{record.uuid}}</dc:identifier>
+            <dc:identifier>{{record.link}}</dc:identifier>
             <dc:rights>{{record.licenses_url}}</dc:rights>
           </oai_dc:dc>
         {% endif %}
@@ -84,7 +84,7 @@
             <dc:description>{{record.abstract}}</dc:description>
             <dc:language>{{record.language}}</dc:language>
             <dc:date>{{record.revised}}</dc:date>
-            <dc:identifier>{{baseURL}}/{{record.uuid}}</dc:identifier>
+            <dc:identifier>{{record.link}}</dc:identifier>
             <dc:rights>{{record.licenses_url}}</dc:rights>
           </cnxdc:dc>
         {% endif %}
@@ -157,7 +157,7 @@
             </ims1_2_1:lifecycle>
             <ims1_2_1:technical>
               <ims1_2_1:format>text/html</ims1_2_1:format>
-              <ims1_2_1:location type="URI">http://cnx.org/contents/{{record.uuid}}@</ims1_2_1:location>
+              <ims1_2_1:location type="URI">{{record.link}}</ims1_2_1:location>
               <ims1_2_1:requirement>
                 <ims1_2_1:type>
                   <ims1_2_1:source>

--- a/cnxarchive/tests/test_oai.py
+++ b/cnxarchive/tests/test_oai.py
@@ -107,7 +107,7 @@ class OaiTestCase(unittest.TestCase):
 
         from ..oai import oai
         oai = oai(self.request)
-        columns = set(['name', 'created', 'revised', 'uuid', 'portal_type',
+        columns = set(['name', 'created', 'revised', 'uuid', 'link', 'portal_type',
                        'language', 'version', 'keywords', 'subjects',
                        'author_emails', 'authors', 'maintainers', 'translators',
                        'abstract', 'licenses_url'])
@@ -117,12 +117,12 @@ class OaiTestCase(unittest.TestCase):
             self.assertEqual(set(result.keys()), columns)
 
     def test_oai_getRecord(self):
-        uuid = "oai:{}:{}".format(self.request.host, COLLECTION_METADATA[u'id'])
+        uuid = COLLECTION_METADATA[u'id']
         self.request.matched_route = mock.Mock()
         self.request.matched_route.name = 'oai'
         self.request.GET = {'verb': 'GetRecord',
                             'metadataPrefix': 'cnx_dc',
-                            'identifier': uuid}
+                            'identifier': "oai:{}:{}".format(self.request.host, uuid)}
 
         from ..oai import oai
         oai = oai(self.request)

--- a/cnxarchive/tests/test_oai.py
+++ b/cnxarchive/tests/test_oai.py
@@ -37,12 +37,33 @@ class OaiTestCase(unittest.TestCase):
         self.request.application_url = 'http://cnx.org'
         config = pyramid_testing.setUp(settings=self.settings,
                                        request=self.request)
+
+        # Set up routes
+        from .. import declare_api_routes
+        declare_api_routes(config)
+
+        # Set up type info
+        from .. import declare_type_info
+        declare_type_info(config)
+
         # Clear all cached searches
         import memcache
         mc_servers = self.settings['memcache-servers'].split()
         mc = memcache.Client(mc_servers, debug=0)
         mc.flush_all()
         mc.disconnect_all()
+
+        # Patch database search so that it's possible to assert call counts
+        # later
+        from .. import cache
+        original_search = cache.database_search
+        self.db_search_call_count = 0
+
+        def patched_search(*args, **kwargs):
+            self.db_search_call_count += 1
+            return original_search(*args, **kwargs)
+        cache.database_search = patched_search
+        self.addCleanup(setattr, cache, 'database_search', original_search)
 
     def tearDown(self):
         pyramid_testing.tearDown()

--- a/cnxarchive/tests/test_oai.py
+++ b/cnxarchive/tests/test_oai.py
@@ -1,0 +1,192 @@
+# -*- coding: utf-8 -*-
+# ###
+# Copyright (c) 2013, Rice University
+# This software is subject to the provisions of the GNU Affero General
+# Public License version 3 (AGPLv3).
+# See LICENCE.txt for details.
+# ###
+import os
+import datetime
+import unittest
+
+try:
+    from unittest import mock
+except ImportError:
+    import mock
+
+from pyramid import testing as pyramid_testing
+
+from . import testing
+from .. import config
+from .test_views import COLLECTION_METADATA
+
+
+@mock.patch('cnxarchive.views.fromtimestamp', mock.Mock(side_effect=testing.mocked_fromtimestamp))
+class OaiTestCase(unittest.TestCase):
+    fixture = testing.data_fixture
+
+    @classmethod
+    def setUpClass(cls):
+        cls.settings = testing.integration_test_settings()
+
+    @testing.db_connect
+    def setUp(self, cursor):
+        self.fixture.setUp()
+        self.request = pyramid_testing.DummyRequest()
+        self.request.headers['HOST'] = 'cnx.org'
+        self.request.application_url = 'http://cnx.org'
+        config = pyramid_testing.setUp(settings=self.settings,
+                                       request=self.request)
+        # Clear all cached searches
+        import memcache
+        mc_servers = self.settings['memcache-servers'].split()
+        mc = memcache.Client(mc_servers, debug=0)
+        mc.flush_all()
+        mc.disconnect_all()
+
+    def tearDown(self):
+        pyramid_testing.tearDown()
+        self.fixture.tearDown()
+
+    def test_oai_general(self):
+        self.request.matched_route = mock.Mock()
+        self.request.matched_route.name = 'oai'
+        self.request.GET = {'verb': 'Identify'}
+
+        from ..oai import oai
+        oai = oai(self.request)
+        self.assertTrue('dateTime' in oai.keys())
+        self.assertEqual(oai['baseURL'], self.request.path_url)
+        self.assertEqual(oai['query_request'], [{'name': 'verb', 'val': 'Identify'}])
+
+    def test_oai_identify(self):
+        self.request.matched_route = mock.Mock()
+        self.request.matched_route.name = 'oai'
+        self.request.GET = {'verb': 'Identify'}
+
+        from ..oai import oai
+        oai = oai(self.request)
+        self.assertEqual(oai['host'], self.request.host)
+        self.assertEqual(oai['adminEmail'], "support@openstax.org")
+        self.assertEqual(oai['repository'], config.REPOSITORY_NAME)
+
+    def test_oai_listIdentifiers(self):
+        from_date = '2016-01-01'
+        until_date = '2017-01-01'
+        self.request.matched_route = mock.Mock()
+        self.request.matched_route.name = 'oai'
+        self.request.GET = {'verb': 'ListIdentifiers',
+                            'metadataPrefix': 'cnx_dc',
+                            'until': until_date}
+
+        from ..oai import oai
+        oai = oai(self.request)
+        for result in oai['results']:
+            self.assertTrue(str(result['revised']) <= until_date)
+            self.assertTrue(set(result.keys()) == set(["revised", "uuid"]))
+
+    def test_oai_listMetadataFormats(self):
+        self.request.matched_route = mock.Mock()
+        self.request.matched_route.name = 'oai'
+        self.request.GET = {'verb': 'ListMetadataFormats'}
+
+        from ..oai import oai
+        oai = oai(self.request)
+        prefixes = [result['prefix'] for result in oai['results']]
+        self.assertEqual(prefixes, ['oai_dc', 'ims1_2_1', 'cnx_dc'])
+
+    def test_oai_listRecords(self):
+        from_date = '2016-01-01'
+        until_date = '2017-01-01'
+        self.request.matched_route = mock.Mock()
+        self.request.matched_route.name = 'oai'
+        self.request.GET = {'verb': 'ListRecords',
+                            'metadataPrefix': 'cnx_dc',
+                            'from': from_date,
+                            'until': until_date}
+
+        from ..oai import oai
+        oai = oai(self.request)
+        columns = set(['name', 'created', 'revised', 'uuid', 'portal_type',
+                       'language', 'version', 'keywords', 'subjects',
+                       'author_emails', 'authors', 'maintainers', 'translators',
+                       'abstract', 'licenses_url'])
+        for result in oai['results']:
+            self.assertTrue(str(result['revised']) >= from_date and
+                            str(result['revised']) <= until_date)
+            self.assertEqual(set(result.keys()), columns)
+
+    def test_oai_getRecord(self):
+        uuid = "oai:{}:{}".format(self.request.host, COLLECTION_METADATA[u'id'])
+        self.request.matched_route = mock.Mock()
+        self.request.matched_route.name = 'oai'
+        self.request.GET = {'verb': 'GetRecord',
+                            'metadataPrefix': 'cnx_dc',
+                            'identifier': uuid}
+
+        from ..oai import oai
+        oai = oai(self.request)
+        self.assertEqual(len(oai['results']), 1)
+        self.assertEqual(oai['results'][0]['uuid'], uuid)
+
+    def test_oai_errors(self):
+        self.request.matched_route = mock.Mock()
+        self.request.matched_route.name = 'oai'
+        from ..oai import oai
+
+        # Invalid Verb
+        self.request.GET = {'verb': 'FakeVerb'}
+        oai_0 = oai(self.request)
+        self.assertEqual(oai_0['error']['code'], 'badVerb')
+
+        # Missing a required argument
+        self.request.GET = {'verb': 'ListRecords'}
+        oai_1 = oai(self.request)
+        self.assertEqual(oai_1['error'], {'code': 'badArgument',
+                                          'message': 'Required argument {} missing'.
+                                                     format(['metadataPrefix'])})
+        # Invalid argument
+        self.request.GET = {'verb': 'Identify', 'fake': 'test'}
+        oai_2 = oai(self.request)
+        self.assertEqual(oai_2['error'], {'code': 'badArgument',
+                                          'message': 'Illegal arguments: {}'.
+                                                     format(['fake'])})
+
+        # Invalid MetadataPrefix
+        self.request.GET = {'verb': 'ListIdentifiers', 'metadataPrefix': 'fake'}
+        oai_3 = oai(self.request)
+        self.assertEqual(oai_3['error'], {'code': 'cannotDisseminateFormat',
+                                          'message': 'metadataPrefix {} not supported'.
+                                                     format('fake')})
+
+        # Invalid Identifier
+        identifier = 'fake_identifier'
+        self.request.GET = {'verb': 'GetRecord', 'metadataPrefix': 'cnx_dc',
+                            'identifier': identifier}
+        oai_4 = oai(self.request)
+        self.assertEqual(oai_4['error'], {'code': 'idDoesNotExist',
+                                          'message': "id does not exist {}".
+                                                     format(identifier)})
+
+        # ListRecords no Records match
+        self.request.GET = {'verb': 'ListRecords', 'metadataPrefix': 'oai_dc',
+                            'from': '2017-01-02', 'until': '2017-01-01'}
+        oai_5 = oai(self.request)
+        self.assertEqual(oai_5['error'], {'code': 'noRecordsMatch',
+                                          'message': 'No matches for the given request'})
+
+        # ListIdentifiers no Records match
+        self.request.GET = {'verb': 'ListIdentifiers', 'metadataPrefix': 'ims1_2_1',
+                            'from': '2017-01-02', 'until': '2017-01-01'}
+        oai_6 = oai(self.request)
+        self.assertEqual(oai_6['error'], {'code': 'noRecordsMatch',
+                                          'message': 'No matches for the given request'})
+
+        # IdDoesNotExist error
+        identifier = 'oai:{}:aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa'.format(self.request.host)
+        self.request.GET = {'verb': 'GetRecord', 'metadataPrefix': 'cnx_dc',
+                            'identifier': identifier}
+        oai_6 = oai(self.request)
+        self.assertEqual(oai_6['error'], {'code': 'idDoesNotExist',
+                                          'message': 'id does not exist {}'.
+                                                     format(identifier)})


### PR DESCRIPTION
oai feed implementing the same features as the legacy oai feed. (sets not supported). Also a change was made in cnx-db on this pull request to update the query used for search to take in extra format elements so that query.sql could be reused for the oai-feed and the search. (https://github.com/Connexions/cnx-db/pull/33)
Syntax changes from legacy OAI feed:
-syntax for query in GetRecord changed to match cnx search api (https://github.com/Connexions/cnx-archive/blob/master/docs/search_api_doc.rst)
-weights are comma separated as one value `?weights=title:5,author:2`
- changed syntax `b_start:int=10` to just be `b_start=10` to match rss and search api
- the sort options are only pubdate, version, and popularity because I reused the interface of search.py and those are the sort options there.