### PR TITLE
Implement get books containing a given page

### DIFF
--- a/cnxarchive/database.py
+++ b/cnxarchive/database.py
@@ -73,6 +73,7 @@ SQL = {
     'get-collated-state': _read_sql_file('get-collated-state'),
     'xpath': _read_sql_file('xpath'),
     'xpath-module': _read_sql_file('xpath-module'),
+    'get-books-containing-page': _read_sql_file('get-books-containing-page'),
     }
 
 

--- a/cnxarchive/tests/views/test_content.py
+++ b/cnxarchive/tests/views/test_content.py
@@ -855,6 +855,7 @@ INSERT INTO trees (nodeid, parent_id, title, childorder, is_collated)
                          'application/json')
         output['canPublish'].sort()
         self.assertEqual(output, {
+            u'books': [],
             u'downloads': [{
                 u'created': None,
                 u'details': u'PDF file, for viewing content offline and printing.',
@@ -1103,6 +1104,14 @@ INSERT INTO trees (nodeid, parent_id, title, childorder, is_collated)
                          'application/json')
         output['canPublish'].sort()
         self.assertEqual(output, {
+            u'books': [{
+                u'authors': [u'OpenStaxCollege'],
+                u'title': u'College Physics',
+                u'ident_hash': u'e79ffde3-7fb4-4af3-9ec8-df648b391597@7.1'},
+                {
+                u'authors': [u'OpenStaxCollege'],
+                u'title': u'<span style="color:red;">Derived</span> Copy of College <i>Physics</i>',
+                u'ident_hash': u'a733d0d2-de9b-43f9-8aa9-f0895036899e@1.1'}],
             u'state': u'current',
             u'canPublish': [
                 u'OpenStaxCollege',


### PR DESCRIPTION
Addresses #499. ~~@philschatz mentioned there may be issues with the route `/contents/{uuid}/included-in`, in the case of a page having the title "included-in." Looking for suggestions for a different route name. `/utils/{uuid}/included-in`?~~ Resolved.
Sibling PR [here in cnx-db](https://github.com/Connexions/cnx-db/pull/37), which is needed for this to work.

Edit: touched up in Connexions/cnx-db#79