### PR TITLE
Fix tree_to_json arg type used in transforms

### DIFF
--- a/cnxarchive/transforms/resolvers.py
+++ b/cnxarchive/transforms/resolvers.py
@@ -349,7 +349,7 @@ class CnxmlToHtmlReferenceResolver(BaseReferenceResolver):
         from cnxepub import flatten_tree_to_ident_hashes  # XXX
         from ..utils import join_ident_hash  # XXX
         plan = self.plpy.prepare(
-            'SELECT tree_to_json($1, $2, FALSE)::json', ('uuid', 'text'))
+            'SELECT tree_to_json($1, $2, FALSE)::json', ('text', 'text'))
         tree = self.plpy.execute(
             plan, (book_uuid, book_version))[0]['tree_to_json']
         if isinstance(tree, basestring):


### PR DESCRIPTION
In CnxmlToHtmlReferenceResolver, when the SQL function tree_to_json is
used, the argument types are set to (uuid, text), but the type
definition of tree_to_json is actually (text, text).