### PR TITLE
Pin webtest to 2.0.27

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ install_requires = (
     'waitress',  # wsgi server
     )
 tests_require = [
-    'webtest'
+    'webtest<=2.0.27'
     ]
 description = "An archive for Connexions documents."
 


### PR DESCRIPTION
The current webtest 2.0.28 has broken one of our tests that returns a unicode
filename in a http header:

```
======================================================================
ERROR: test_exports_wo_version (cnxarchive.tests.test_functional.IdentHashMissingVersionTestCase)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/var/cnx/venvs/publishing/src/cnx-archive/cnxarchive/tests/test_functional.py", line 351, in test_exports_wo_version
    resp = resp.follow()
  File "/var/cnx/venvs/publishing/local/lib/python2.7/site-packages/webtest/response.py", line 102, in follow
    return self._follow(**kw)
  File "/var/cnx/venvs/publishing/local/lib/python2.7/site-packages/webtest/response.py", line 90, in _follow
    return self.test_app.get(abslocation, **kw)
  File "/var/cnx/venvs/publishing/local/lib/python2.7/site-packages/webtest/app.py", line 331, in get
    expect_errors=expect_errors)
  File "/var/cnx/venvs/publishing/local/lib/python2.7/site-packages/webtest/app.py", line 625, in do_request
    res = req.get_response(app, catch_exc_info=True)
  File "/var/cnx/venvs/publishing/local/lib/python2.7/site-packages/webob/request.py", line 1312, in send
    application, catch_exc_info=True)
  File "/var/cnx/venvs/publishing/local/lib/python2.7/site-packages/webob/request.py", line 1280, in call_application
    app_iter = application(self.environ, start_response)
  File "/var/cnx/venvs/publishing/local/lib/python2.7/site-packages/webtest/lint.py", line 199, in lint_app
    iterator = application(environ, start_response_wrapper)
  File "/var/cnx/venvs/publishing/local/lib/python2.7/site-packages/pyramid/router.py", line 271, in __call__
    return response(environ, start_response)
  File "/var/cnx/venvs/publishing/local/lib/python2.7/site-packages/webob/response.py", line 1310, in __call__
    start_response(self.status, headerlist)
  File "/var/cnx/venvs/publishing/local/lib/python2.7/site-packages/webtest/lint.py", line 189, in start_response_wrapper
    check_headers(headers)
  File "/var/cnx/venvs/publishing/local/lib/python2.7/site-packages/webtest/lint.py", line 454, in check_headers
    "%r is not a valid latin1 string" % (value,)
  File "/var/cnx/venvs/publishing/local/lib/python2.7/site-packages/webtest/lint.py", line 420, in _assert_latin1_str
    string.encode('latin1')
UnicodeDecodeError: 'ascii' codec can't decode byte 0xf8 in position 29: ordinal not in range(128)

----------------------------------------------------------------------
```

See https://github.com/Pylons/webtest/commit/7d539b6a924edb7af728b3c47b71a06944b41e1d