### PR TITLE
fix setup.py to see templates folder

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -7,5 +7,6 @@ recursive-include cnxarchive/data *
 recursive-include cnxarchive/tests/data *
 recursive-include cnxarchive/xsl *
 recursive-include cnxarchive/scripts/export_epub/sql *
+recursive-include cnxarchive/views/templates *
 include versioneer.py
 include cnxarchive/_version.py

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,8 @@ setup(
     tests_require=tests_require,
     include_package_data=True,
     package_data={
-        'cnxarchive': ['sql/*.sql', 'sql/*/*.sql', 'data/*.*', '*.yaml'],
+        'cnxarchive': ['sql/*.sql', 'sql/*/*.sql', 'data/*.*', '*.yaml',
+                       'views/templates/*.*'],
         'cnxarchive.tests': ['data/*.*'],
         },
     cmdclass=versioneer.get_cmdclass(),


### PR DESCRIPTION
added an extra path to `package_data` in setup.py so that when running serve the templates can be found

same as (https://github.com/Connexions/cnx-publishing/pull/169) but for archive