### PR TITLE
Add rhaptos.cnxmlutils version to index.cnxml.html

### DIFF
--- a/cnxarchive/tests/transforms/test_converters.py
+++ b/cnxarchive/tests/transforms/test_converters.py
@@ -31,6 +31,16 @@ class Cnxml2HtmlTests(unittest.TestCase):
         with open(path, 'r') as fp:
             return fp.read()
 
+    def test_dev_ctoh_version(self):
+        import rhaptos.cnxmlutils
+        # Mimic the in-database environment: no path
+        os.environ['PATH'] = ''
+        reload(rhaptos.cnxmlutils)
+        cnxml = self.get_file('m42033-1.3.cnxml')
+        content = self.call_target(cnxml)
+
+        self.assertNotIn('0+unknown', content)
+
     def test_success(self):
         # Case to test the transformation of cnxml to html.
         cnxml = self.get_file('m42033-1.3.cnxml')
@@ -40,6 +50,10 @@ class Cnxml2HtmlTests(unittest.TestCase):
 
         self.assertIn('<html', content)
         self.assertIn('<body', content)
+
+        # Check for ctoh version
+        import rhaptos.cnxmlutils
+        self.assertIn(rhaptos.cnxmlutils.__version__, content)
 
     @unittest.skip("the DTD files are not externally available")
     def test_module_transform_entity_expansion(self):

--- a/cnxarchive/transforms/converters.py
+++ b/cnxarchive/transforms/converters.py
@@ -8,7 +8,6 @@
 """CNXML <-> HTML conversion code."""
 
 import os
-import sys
 from io import BytesIO
 
 import rhaptos.cnxmlutils


### PR DESCRIPTION
When using the rhaptos.cnxmlutils xsl stylesheet on index.cnxml, pass in
rhaptos.cnxmlutils version so it appears in the `<body>` tag in
index.cnxml.html.

Extra code was necessary for rhaptos.cnxmlutils to return its version
when `git` is required.  By default, postgres python triggers have
nothing in $PATH, so versioneer was returning "0+unknown" as the version
number for rhaptos.cnxmlutils.  We need to add `/usr/bin` to $PATH for
versioneer to work correctly.