### PR TITLE
use new method to get latest version

### DIFF
--- a/cnxarchive/database.py
+++ b/cnxarchive/database.py
@@ -51,6 +51,7 @@ SQL = {
     'get-resource-by-filename': _read_sql_file('get-resource-by-filename'),
     'get-resourceid-by-filename': _read_sql_file('get-resourceid-by-filename'),
     'get-tree-by-uuid-n-version': _read_sql_file('get-tree-by-uuid-n-version'),
+    'get-module-latest-version': _read_sql_file('get-module-latest-version'),
     'get-module-versions': _read_sql_file('get-module-versions'),
     'get-module-uuid': _read_sql_file('get-module-uuid'),
     'get-subject-list': _read_sql_file('get-subject-list'),

--- a/cnxarchive/views/helpers.py
+++ b/cnxarchive/views/helpers.py
@@ -43,7 +43,7 @@ def get_latest_version(uuid_):
     settings = get_current_registry().settings
     with psycopg2.connect(settings[config.CONNECTION_STRING]) as db_connection:
         with db_connection.cursor() as cursor:
-            cursor.execute(SQL['get-module-versions'], {'id': uuid_})
+            cursor.execute(SQL['get-module-latest-version'], {'id': uuid_})
             try:
                 return cursor.fetchone()[0]
             except (TypeError, IndexError,):  # None returned


### PR DESCRIPTION
When redirecting from lack-of-version to latest version, pay attention to what's in latest_modules, rather than finding the 'most recent' from all versions.
depends on  https://github.com/Connexions/cnx-db/pull/64
Fixes #524 