### PR TITLE
Explicitly close all psycopg2 db connections

### DIFF
--- a/cnxarchive/database.py
+++ b/cnxarchive/database.py
@@ -6,6 +6,7 @@
 # See LICENCE.txt for details.
 # ###
 """Database models and utilities."""
+import contextlib
 import os
 import json
 import psycopg2
@@ -73,12 +74,18 @@ SQL = {
     }
 
 
+@contextlib.contextmanager
 def db_connect(connection_string=None):
     """Function to supply a database connection object."""
     if connection_string is None:
         settings = get_current_registry().settings
         connection_string = settings[config.CONNECTION_STRING]
-    return psycopg2.connect(connection_string)
+    db_conn = psycopg2.connect(connection_string)
+    try:
+        with db_conn:
+            yield db_conn
+    finally:
+        db_conn.close()
 
 
 def get_module_ident_from_ident_hash(ident_hash, cursor):

--- a/cnxarchive/scripts/hits_counter.py
+++ b/cnxarchive/scripts/hits_counter.py
@@ -86,7 +86,8 @@ def main(argv=None):
 
     # Insert the hits into the database.
     connection_string = settings[config.CONNECTION_STRING]
-    with psycopg2.connect(connection_string) as db_connection:
+    db_connection = psycopg2.connect(connection_string)
+    with db_connection:
         with db_connection.cursor() as cursor:
             for ident_hash, hit_count in hits.items():
                 cursor.execute("""\
@@ -98,6 +99,7 @@ def main(argv=None):
                                (start_timestamp, end_timestamp, hit_count,
                                 ident_hash))
             cursor.execute("SELECT update_hit_ranks();")
+    db_connection.close()
     return 0
 
 

--- a/cnxarchive/scripts/initializedb.py
+++ b/cnxarchive/scripts/initializedb.py
@@ -45,11 +45,13 @@ def main(argv=None):
 
     if args.with_example_data:
         connection_string = settings[config.CONNECTION_STRING]
-        with psycopg2.connect(connection_string) as db_connection:
+        db_connection = psycopg2.connect(connection_string)
+        with db_connection:
             with db_connection.cursor() as cursor:
                 for filepath in EXAMPLE_DATA_FILEPATHS:
                     with open(filepath, 'r') as fb:
                         cursor.execute(fb.read())
+        db_connection.close()
     return 0
 
 

--- a/cnxarchive/views/exports.py
+++ b/cnxarchive/views/exports.py
@@ -9,14 +9,12 @@
 import os
 import logging
 
-import psycopg2
-import psycopg2.extras
 from pyramid import httpexceptions
 from pyramid.threadlocal import get_current_registry, get_current_request
 from pyramid.view import view_config
 
 from .. import config
-
+from ..database import db_connect
 from ..utils import (
     slugify, fromtimestamp, split_ident_hash,
     )
@@ -51,7 +49,7 @@ def get_export(request):
     ident_hash, type = args['ident_hash'], args['type']
     id, version = split_ident_hash(ident_hash)
 
-    with psycopg2.connect(settings[config.CONNECTION_STRING]) as db_connection:
+    with db_connect() as db_connection:
         with db_connection.cursor() as cursor:
             try:
                 filename, mimetype, size, modtime, state, file_content = \

--- a/cnxarchive/views/extras.py
+++ b/cnxarchive/views/extras.py
@@ -9,13 +9,11 @@
 import json
 import logging
 
-import psycopg2
-import psycopg2.extras
 from pyramid.threadlocal import get_current_registry
 from pyramid.view import view_config
 
 from .. import config
-from ..database import SQL
+from ..database import SQL, db_connect
 
 logger = logging.getLogger('cnxarchive')
 
@@ -82,8 +80,7 @@ def _get_licenses(cursor):
 @view_config(route_name='extras', request_method='GET')
 def extras(request):
     """Return a dict with archive metadata for webview."""
-    settings = get_current_registry().settings
-    with psycopg2.connect(settings[config.CONNECTION_STRING]) as db_connection:
+    with db_connect() as db_connection:
         with db_connection.cursor() as cursor:
             metadata = {
                 'languages_and_count': _get_available_languages_and_count(

--- a/cnxarchive/views/helpers.py
+++ b/cnxarchive/views/helpers.py
@@ -8,13 +8,11 @@
 """Helpers Used in Multiple Views."""
 import logging
 
-import psycopg2
-import psycopg2.extras
 from pyramid import httpexceptions
 from pyramid.threadlocal import get_current_registry
 
 from .. import config
-from ..database import SQL
+from ..database import SQL, db_connect
 
 from ..utils import portaltype_to_mimetype
 
@@ -27,8 +25,7 @@ logger = logging.getLogger('cnxarchive')
 
 
 def get_uuid(shortid):
-    settings = get_current_registry().settings
-    with psycopg2.connect(settings[config.CONNECTION_STRING]) as db_connection:
+    with db_connect() as db_connection:
         with db_connection.cursor() as cursor:
             cursor.execute(SQL['get-module-uuid'], {'id': shortid})
             try:
@@ -40,8 +37,7 @@ def get_uuid(shortid):
 
 
 def get_latest_version(uuid_):
-    settings = get_current_registry().settings
-    with psycopg2.connect(settings[config.CONNECTION_STRING]) as db_connection:
+    with db_connect() as db_connection:
         with db_connection.cursor() as cursor:
             cursor.execute(SQL['get-module-latest-version'], {'id': uuid_})
             try:

--- a/cnxarchive/views/in_book_search.py
+++ b/cnxarchive/views/in_book_search.py
@@ -9,13 +9,11 @@
 import json
 import logging
 
-import psycopg2
-import psycopg2.extras
 from pyramid.threadlocal import get_current_registry
 from pyramid.view import view_config
 
 from .. import config
-from ..database import SQL
+from ..database import SQL, db_connect
 from ..utils import (
     IdentHashShortId, IdentHashMissingVersion, split_ident_hash
     )
@@ -47,9 +45,7 @@ def in_book_search(request):
     args['uuid'] = id
     args['version'] = version
 
-    settings = get_current_registry().settings
-    connection_string = settings[config.CONNECTION_STRING]
-    with psycopg2.connect(connection_string) as db_connection:
+    with db_connect() as db_connection:
         with db_connection.cursor() as cursor:
             cursor.execute(SQL['get-collated-state'], args)
             res = cursor.fetchall()
@@ -108,9 +104,7 @@ def in_book_search_highlighted_results(request):
     args['uuid'] = id
     args['version'] = version
 
-    settings = get_current_registry().settings
-    connection_string = settings[config.CONNECTION_STRING]
-    with psycopg2.connect(connection_string) as db_connection:
+    with db_connect() as db_connection:
         with db_connection.cursor() as cursor:
             cursor.execute(SQL['get-collated-state'], args)
             res = cursor.fetchall()

--- a/cnxarchive/views/recent.py
+++ b/cnxarchive/views/recent.py
@@ -8,11 +8,11 @@
 """Recent RSS feed View."""
 import logging
 
-import psycopg2
 import psycopg2.extras
 from pyramid.view import view_config
 
 from .. import config
+from ..database import db_connect
 
 logger = logging.getLogger('cnxarchive')
 
@@ -32,7 +32,7 @@ def format_author(personids, settings):
                 FROM persons
                 WHERE personid = ANY (%s);
                 """
-    with psycopg2.connect(settings[config.CONNECTION_STRING]) as db_connection:
+    with db_connect() as db_connection:
             with db_connection.cursor() as cursor:
                 cursor.execute(statement, vars=(personids,))
                 authors_list = cursor.fetchall()
@@ -74,7 +74,7 @@ def recent(request):
                 ORDER BY revised DESC
                 LIMIT (%s) OFFSET (%s);
                 """
-    with psycopg2.connect(settings[config.CONNECTION_STRING]) as db_c:
+    with db_connect() as db_c:
             with db_c.cursor(cursor_factory=psycopg2.extras.DictCursor) as cur:
                 cur.execute(statement,
                             vars=(portal_type, num_entries, start_entry))

--- a/cnxarchive/views/resource.py
+++ b/cnxarchive/views/resource.py
@@ -8,14 +8,12 @@
 """Resource Views."""
 import logging
 
-import psycopg2
-import psycopg2.extras
 from pyramid import httpexceptions
 from pyramid.threadlocal import get_current_registry
 from pyramid.view import view_config
 
 from .. import config
-from ..database import SQL
+from ..database import SQL, db_connect
 
 logger = logging.getLogger('cnxarchive')
 
@@ -32,11 +30,10 @@ logger = logging.getLogger('cnxarchive')
 @view_config(route_name='resource', request_method='GET')
 def get_resource(request):
     """Retrieve a file's data."""
-    settings = get_current_registry().settings
     hash = request.matchdict['hash']
 
     # Do the file lookup
-    with psycopg2.connect(settings[config.CONNECTION_STRING]) as db_connection:
+    with db_connect() as db_connection:
         with db_connection.cursor() as cursor:
             args = dict(hash=hash)
             cursor.execute(SQL['get-resource'], args)

--- a/cnxarchive/views/search.py
+++ b/cnxarchive/views/search.py
@@ -9,14 +9,12 @@
 import json
 import logging
 
-import psycopg2
-import psycopg2.extras
 from pyramid.threadlocal import get_current_registry
 from pyramid.view import view_config
 
 from .. import config
 from .. import cache
-from ..database import SQL
+from ..database import SQL, db_connect
 from ..search import (
     DEFAULT_PER_PAGE, QUERY_TYPES, DEFAULT_QUERY_TYPE,
     Query,
@@ -147,10 +145,8 @@ def search(request):
         authors_results = []
         limits = results['query']['limits']
         index = 0
-        settings = get_current_registry().settings
-        connection = settings[config.CONNECTION_STRING]
         statement = SQL['get-users-by-ids']
-        with psycopg2.connect(connection) as db_connection:
+        with db_connect() as db_connection:
             with db_connection.cursor() as cursor:
                 for idx, limit in enumerate(limits):
                     if limit['tag'] == 'authorID':

--- a/cnxarchive/views/sitemap.py
+++ b/cnxarchive/views/sitemap.py
@@ -9,12 +9,11 @@
 import logging
 from re import compile
 
-import psycopg2
-import psycopg2.extras
 from pyramid.threadlocal import get_current_registry
 from pyramid.view import view_config
 
 from .. import config
+from ..database import db_connect
 from ..sitemap import Sitemap
 
 PAGES_TO_BLOCK = [
@@ -49,10 +48,8 @@ def notblocked(page):
 @view_config(route_name='sitemap', request_method='GET')
 def sitemap(request):
     """Return a sitemap xml file for search engines."""
-    settings = get_current_registry().settings
     xml = Sitemap()
-    connection_string = settings[config.CONNECTION_STRING]
-    with psycopg2.connect(connection_string) as db_connection:
+    with db_connect() as db_connection:
         with db_connection.cursor() as cursor:
             # FIXME
             # magic number limit comes from Google policy - will need to split

--- a/cnxarchive/views/xpath.py
+++ b/cnxarchive/views/xpath.py
@@ -3,7 +3,6 @@ import re
 from urllib import urlencode
 
 import psycopg2
-import psycopg2.extras
 from pyramid import httpexceptions
 from lxml import etree
 from pyramid.settings import asbool
@@ -11,8 +10,7 @@ from pyramid.threadlocal import get_current_registry, get_current_request
 from pyramid.view import view_config
 
 from .. import config
-from ..database import (
-    SQL, get_tree)
+from ..database import SQL, get_tree, db_connect
 from ..utils import (
     IdentHashShortId, IdentHashMissingVersion, IdentHashSyntaxError,
     split_ident_hash, COLLECTION_MIMETYPE, join_ident_hash
@@ -63,7 +61,7 @@ def xpath_book(request, uuid, version, return_json=True):
 
 def get_page_content(uuid, version, filename='index.cnxml'):
     settings = get_current_registry().settings
-    with psycopg2.connect(settings[config.CONNECTION_STRING]) as db_connection:
+    with db_connect() as db_connection:
         with db_connection.cursor() as cursor:
             cursor.execute(SQL['get-resource-by-filename'],
                            {'id': uuid, 'version': version,
@@ -126,7 +124,7 @@ def execute_xpath(xpath_string, sql_function, uuid, version):
     """Executes either xpath or xpath-module SQL function with given input
     params."""
     settings = get_current_registry().settings
-    with psycopg2.connect(settings[config.CONNECTION_STRING]) as db_connection:
+    with db_connect() as db_connection:
         with db_connection.cursor() as cursor:
 
             try:
@@ -177,7 +175,7 @@ def xpath(request):
         raise httpexceptions.HTTPBadRequest
 
     settings = get_current_registry().settings
-    with psycopg2.connect(settings[config.CONNECTION_STRING]) as db_connection:
+    with db_connect() as db_connection:
         with db_connection.cursor() as cursor:
             result = get_content_metadata(uuid, version, cursor)
 


### PR DESCRIPTION
The psycopg2 db connection `with` statement does not actually close the
database connection causing lots of idle postgres connections on the
production servers.  An idle postgres connection can be found by doing
`ps aux` on the database servers, for example you will see something
like this:

```
postgres 25498  0.0  0.5 302652 10996 ?        Ss   09:31   0:00 postgres: cnxarchive cnxarchive 192.168.122.250(42646) idle
```

On http://initd.org/psycopg/docs/usage.html#with-statement

"Note that, unlike file objects or other resources, exiting the
connection’s with block doesn't close the connection but only the
transaction associated with it"

This change creates a `db_connect` function that is like
`psycopg2.connect` but closes the db connection when exiting the `with`
block.