### PR TITLE
Fix broken tests in cnx-archive master following cnx-db updates

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,7 @@ RUN apt-get update && apt-get install -y \
     gcc \
     zlib1g-dev \
     wget \
+    tzdata \
  && rm -rf /var/lib/apt/lists/*
 
 COPY . /src/

--- a/cnxarchive/tests/test_database.py
+++ b/cnxarchive/tests/test_database.py
@@ -1722,7 +1722,7 @@ class UpdateLatestTriggerTestCase(unittest.TestCase):
         module_ident, uuid = cursor.fetchone()
 
         cursor.execute('''INSERT INTO modules VALUES (
-        DEFAULT, 'Module', 'm1', %s, '1.1', 'Changed name of m1 again',
+        DEFAULT, 'Module', 'm1', %s, '1.3', 'Changed name of m1 again',
         '2013-07-31 12:00:00.000000+02', '2013-10-14 18:05:31.000000+02',
         1, 11, '', '', '', DEFAULT, NULL, 'en', '{}', '{}', '{}',
         NULL, NULL, NULL, 3, NULL, NULL)
@@ -1730,7 +1730,7 @@ class UpdateLatestTriggerTestCase(unittest.TestCase):
         module_ident, uuid = cursor.fetchone()
 
         cursor.execute('''INSERT INTO modules VALUES (
-        DEFAULT, 'Module', 'm1', %s, '1.1', 'Changed name of m1',
+        DEFAULT, 'Module', 'm1', %s, '1.2', 'Changed name of m1',
         '2013-07-31 12:00:00.000000+02', '2013-10-14 17:08:57.000000+02',
         1, 11, '', '', '', DEFAULT, NULL, 'en', '{}', '{}', '{}',
         NULL, NULL, NULL, 2, NULL, NULL)

--- a/cnxarchive/tests/views/test_in_book_search.py
+++ b/cnxarchive/tests/views/test_in_book_search.py
@@ -137,19 +137,9 @@ class InBookViewsTestCase(unittest.TestCase):
         IN_BOOK_SEARCH_RESULT = {
             u'results': {
                 u'items': [{
-                    u'id': u'24a2ed13-22a6-47d6-97a3-c8aa8d54ac6d@2',
-                    u'matches': u'3',
-                    u'rank': u'0.05',
-                    u'snippet': u'have in mind the forces of friction, '
-                                u'<span class="q-match">air</span> or '
-                                u'<span class="q-match">liquid</span> '
-                                u'<span class="q-match">drag</span>, '
-                                u'and deformation',
-                    u'title': u'Introduction: Further Applications of '
-                              u'Newton\u2019s Laws'}, {
                     u'id': u'26346a42-84b9-48ad-9f6a-62303c16ad41@6',
                     u'matches': u'79',
-                    u'rank': u'0.00415517',
+                    u'rank': u'7.9',
                     u'snippet': u'absence of <span '
                                 u'class="q-match">air</span> <span '
                                 u'class="q-match">drag</span> (b) with '
@@ -159,17 +149,73 @@ class InBookViewsTestCase(unittest.TestCase):
                     u'title': u'<span class="q-match">Drag</span> Forces'}, {
                     u'id': u'56f1c5c1-4014-450d-a477-2121e276beca@8',
                     u'matches': u'13',
-                    u'rank': u'2.51826e-05',
-                    u'snippet': u'compress gases and extremely difficult '
-                                u'to compress <span '
-                                u'class="q-match">liquids</span> and '
-                                u'solids. For example, <span '
-                                u'class="q-match">air</span> in a wine '
-                                u'bottle is compressed when',
-                    u'title': u'Elasticity: Stress and Strain'}],
+                    u'rank': u'1.3',
+                    u'snippet': u'break. (This is the function of the <span '
+                                u'class="q-match">air</span> above <span class'
+                                u'="q-match">liquids</span> in glass '
+                                u'containers.)\n      \n      \n      Problems'
+                                u' & Exercises\n      \n      During a circus',
+                    u'title': u'Elasticity: Stress and Strain'}, {
+                    u'id': u'24a2ed13-22a6-47d6-97a3-c8aa8d54ac6d@2',
+                    u'matches': u'3',
+                    u'rank': u'0.3',
+                    u'snippet': u'have in mind the forces of friction, <span '
+                                u'class="q-match">air</span> or <span class="'
+                                u'q-match">liquid</span> <span class="q-match"'
+                                u'>drag</span>, and deformation',
+                    u'title': u'Introduction: Further Applications of '
+                              u'Newton’s Laws'}, {
+                    u'id': u'ea271306-f7f2-46ac-b2ec-1d80ff186a59@5',
+                    u'matches': u'3',
+                    u'rank': u'0.3',
+                    u'snippet': u'deformed sideways by frictional force as the'
+                                u' probe is <span class="q-match">dragged'
+                                u'</span> across a surface. Measurements of '
+                                u'how the force varies',
+                    u'title': u'Friction'}, {
+                    u'id': u'209deb1f-1a46-4369-9e0d-18674cf58a3e@7',
+                    u'matches': u'1',
+                    u'rank': u'0.1',
+                    u'snippet': u'these special topic essays, macroscopic '
+                                u'phenomena (such as <span class="q-match">air'
+                                u'</span> pressure) are explained with '
+                                u'submicroscopic phenomena (such as atoms '
+                                u'bouncing',
+                    u'title': u'Preface'}, {
+                    u'id': u'c8bdbabc-62b1-4a5f-b291-982ab25756d7@6',
+                    u'matches': u'1',
+                    u'rank': u'0.1',
+                    u'snippet': u'construction, while distances in kilometers '
+                                u'are appropriate for <span class="q-match">'
+                                u'air</span> travel, and the tiny measure of '
+                                u'nanometers are convenient in optical',
+                    u'title': u'Physical Quantities and Units'}, {
+                    u'id': u'ae3e18de-638d-4738-b804-dc69cd4db3a3@5',
+                    u'matches': u'1',
+                    u'rank': u'0.1',
+                    u'snippet': u'size 8{"ref"} } } {}\n                '
+                                u'\n            \n            coefficient of '
+                                u'performance for refrigerators and <span '
+                                u'class="q-match">air</span> conditioners'
+                                u'\n          \n          \n            '
+                                u'\n              \n                '
+                                u'\n                    \n          '
+                                u'            \n                        cos\n'
+                                u'                        \u03b8\n           '
+                                u'           \n                    \n        '
+                                u'            \n                  \n         '
+                                u'     \n                  \n                '
+                                u'    \n                      \n             '
+                                u'           cos\n                        '
+                                u'\u03b8\n                      \n           '
+                                u'         \n                    \n          '
+                                u'        \n                   size 12{"cos"'
+                                u'\u03b8} {}\n                \n            '
+                                u'\n            cosine',
+                    u'title': u'Glossary of Key Symbols and Notation'}],
                 u'query': {u'id': u'e79ffde3-7fb4-4af3-9ec8-df648b391597@7.1',
                            u'search_term': u'air or liquid drag'},
-                u'total': 3}}
+                u'total': 7}}
 
         self.assertEqual(status, '200 OK')
         self.assertEqual(content_type, 'application/json')


### PR DESCRIPTION
- Fix update latest trigger tests to use legacy version in inserts

  We have changed to updating latest_modules by comparing the major and
  minor versions instead of using "revised".  The update latest trigger
  tests insert legacy versions (`1.1`, `1.1`, `1.1`) and major versions
  (`1`, `3`, `2`).  The major versions were actually getting overwritten
  by the legacy compatible triggers, causing all the modules to have the
  major version "1".  Change the test to use correct legacy versions
  `1.1`, `1.3`, `1.2`.

- Install tzdata for cnx-archive docker image

  The ubuntu 16.04 docker image does not have tzdata installed.  So when
  we need to use timezones, it just returns the time in UTC.
  
  ```
  root@e9d0eb00903e:/# date
  Fri Oct 13 01:04:05 UTC 2017
  root@e9d0eb00903e:/# TZ=Europe/London date
  Fri Oct 13 01:04:09 Europe 2017
  root@e9d0eb00903e:/# tzselect
  /usr/bin/tzselect: line 180: /usr/share/zoneinfo/iso3166.tab: No such file or directory
  /usr/bin/tzselect: time zone files are not set up correctly
  ```
  
  Add `tzdata` to the list of packages to install using `apt-get install`.

- Update book search test following changes in book search sql

  The book search sql has been changed in cnx-db to search OR terms,
  rather than AND them.

