### PR TITLE
provide query_type parameterization for AND vs OR queries in-book-search

### DIFF
--- a/cnxarchive/tests/views/test_in_book_search.py
+++ b/cnxarchive/tests/views/test_in_book_search.py
@@ -18,6 +18,126 @@ from ...utils import IdentHashShortId, IdentHashMissingVersion
 from .. import testing
 
 
+IN_BOOK_AND_SEARCH_RESULT = {
+    u'results': {
+        u'items': [{
+            u'id': u'24a2ed13-22a6-47d6-97a3-c8aa8d54ac6d@2',
+            u'matches': u'3',
+            u'rank': u'0.05',
+            u'snippet': u'have in mind the forces of friction, '
+                        u'<span class="q-match">air</span> or '
+                        u'<span class="q-match">liquid</span> '
+                        u'<span class="q-match">drag</span>, '
+                        u'and deformation',
+            u'title': u'Introduction: Further Applications of '
+                      u'Newton\u2019s Laws'}, {
+            u'id': u'26346a42-84b9-48ad-9f6a-62303c16ad41@6',
+            u'matches': u'79',
+            u'rank': u'0.00415517',
+            u'snippet': u'absence of <span class="q-match">air</span> '
+                        u'<span class="q-match">drag</span> (b) with '
+                        u'<span class="q-match">air</span> '
+                        u'<span class="q-match">drag</span>. '
+                        u'Take the size across of the drop',
+            u'title': u'<span class="q-match">Drag</span> Forces'}, {
+            u'id': u'56f1c5c1-4014-450d-a477-2121e276beca@8',
+            u'matches': u'13',
+            u'rank': u'2.51826e-05',
+            u'snippet': u'compress gases and extremely difficult to '
+                        u'compress <span class="q-match">liquids'
+                        u'</span> and solids. For example, <span '
+                        u'class="q-match">air</span> in a wine bottle '
+                        u'is compressed when',
+            u'title': u'Elasticity: Stress and Strain'}],
+        u'query': {u'id': u'e79ffde3-7fb4-4af3-9ec8-df648b391597@7.1',
+                   u'search_term': u'air or liquid drag'},
+        u'total': 3}}
+
+
+IN_BOOK_OR_SEARCH_RESULT = {
+    u'results': {
+        u'items': [{
+            u'id': u'26346a42-84b9-48ad-9f6a-62303c16ad41@6',
+            u'matches': u'79',
+            u'rank': u'7.9',
+            u'snippet': u'absence of <span '
+                        u'class="q-match">air</span> <span '
+                        u'class="q-match">drag</span> (b) with '
+                        u'<span class="q-match">air</span> <span '
+                        u'class="q-match">drag</span>. Take the '
+                        u'size across of the drop',
+            u'title': u'<span class="q-match">Drag</span> Forces'}, {
+            u'id': u'56f1c5c1-4014-450d-a477-2121e276beca@8',
+            u'matches': u'13',
+            u'rank': u'1.3',
+            u'snippet': u'break. (This is the function of the <span '
+                        u'class="q-match">air</span> above <span class'
+                        u'="q-match">liquids</span> in glass '
+                        u'containers.)\n      \n      \n      Problems'
+                        u' & Exercises\n      \n      During a circus',
+            u'title': u'Elasticity: Stress and Strain'}, {
+            u'id': u'24a2ed13-22a6-47d6-97a3-c8aa8d54ac6d@2',
+            u'matches': u'3',
+            u'rank': u'0.3',
+            u'snippet': u'have in mind the forces of friction, <span '
+                        u'class="q-match">air</span> or <span class="'
+                        u'q-match">liquid</span> <span class="q-match"'
+                        u'>drag</span>, and deformation',
+            u'title': u'Introduction: Further Applications of '
+                      u'Newton’s Laws'}, {
+            u'id': u'ea271306-f7f2-46ac-b2ec-1d80ff186a59@5',
+            u'matches': u'3',
+            u'rank': u'0.3',
+            u'snippet': u'deformed sideways by frictional force as the'
+                        u' probe is <span class="q-match">dragged'
+                        u'</span> across a surface. Measurements of '
+                        u'how the force varies',
+            u'title': u'Friction'}, {
+            u'id': u'209deb1f-1a46-4369-9e0d-18674cf58a3e@7',
+            u'matches': u'1',
+            u'rank': u'0.1',
+            u'snippet': u'these special topic essays, macroscopic '
+                        u'phenomena (such as <span class="q-match">air'
+                        u'</span> pressure) are explained with '
+                        u'submicroscopic phenomena (such as atoms '
+                        u'bouncing',
+            u'title': u'Preface'}, {
+            u'id': u'c8bdbabc-62b1-4a5f-b291-982ab25756d7@6',
+            u'matches': u'1',
+            u'rank': u'0.1',
+            u'snippet': u'construction, while distances in kilometers '
+                        u'are appropriate for <span class="q-match">'
+                        u'air</span> travel, and the tiny measure of '
+                        u'nanometers are convenient in optical',
+            u'title': u'Physical Quantities and Units'}, {
+            u'id': u'ae3e18de-638d-4738-b804-dc69cd4db3a3@5',
+            u'matches': u'1',
+            u'rank': u'0.1',
+            u'snippet': u'size 8{"ref"} } } {}\n                '
+                        u'\n            \n            coefficient of '
+                        u'performance for refrigerators and <span '
+                        u'class="q-match">air</span> conditioners'
+                        u'\n          \n          \n            '
+                        u'\n              \n                '
+                        u'\n                    \n          '
+                        u'            \n                        cos\n'
+                        u'                        \u03b8\n           '
+                        u'           \n                    \n        '
+                        u'            \n                  \n         '
+                        u'     \n                  \n                '
+                        u'    \n                      \n             '
+                        u'           cos\n                        '
+                        u'\u03b8\n                      \n           '
+                        u'         \n                    \n          '
+                        u'        \n                   size 12{"cos"'
+                        u'\u03b8} {}\n                \n            '
+                        u'\n            cosine',
+            u'title': u'Glossary of Key Symbols and Notation'}],
+        u'query': {u'id': u'e79ffde3-7fb4-4af3-9ec8-df648b391597@7.1',
+                   u'search_term': u'air or liquid drag'},
+        u'total': 7}}
+
+
 class InBookViewsTestCase(unittest.TestCase):
     fixture = testing.data_fixture
     maxDiff = 10000
@@ -134,92 +254,49 @@ class InBookViewsTestCase(unittest.TestCase):
         status = self.request.response.status
         content_type = self.request.response.content_type
 
-        IN_BOOK_SEARCH_RESULT = {
-            u'results': {
-                u'items': [{
-                    u'id': u'26346a42-84b9-48ad-9f6a-62303c16ad41@6',
-                    u'matches': u'79',
-                    u'rank': u'7.9',
-                    u'snippet': u'absence of <span '
-                                u'class="q-match">air</span> <span '
-                                u'class="q-match">drag</span> (b) with '
-                                u'<span class="q-match">air</span> <span '
-                                u'class="q-match">drag</span>. Take the '
-                                u'size across of the drop',
-                    u'title': u'<span class="q-match">Drag</span> Forces'}, {
-                    u'id': u'56f1c5c1-4014-450d-a477-2121e276beca@8',
-                    u'matches': u'13',
-                    u'rank': u'1.3',
-                    u'snippet': u'break. (This is the function of the <span '
-                                u'class="q-match">air</span> above <span class'
-                                u'="q-match">liquids</span> in glass '
-                                u'containers.)\n      \n      \n      Problems'
-                                u' & Exercises\n      \n      During a circus',
-                    u'title': u'Elasticity: Stress and Strain'}, {
-                    u'id': u'24a2ed13-22a6-47d6-97a3-c8aa8d54ac6d@2',
-                    u'matches': u'3',
-                    u'rank': u'0.3',
-                    u'snippet': u'have in mind the forces of friction, <span '
-                                u'class="q-match">air</span> or <span class="'
-                                u'q-match">liquid</span> <span class="q-match"'
-                                u'>drag</span>, and deformation',
-                    u'title': u'Introduction: Further Applications of '
-                              u'Newton’s Laws'}, {
-                    u'id': u'ea271306-f7f2-46ac-b2ec-1d80ff186a59@5',
-                    u'matches': u'3',
-                    u'rank': u'0.3',
-                    u'snippet': u'deformed sideways by frictional force as the'
-                                u' probe is <span class="q-match">dragged'
-                                u'</span> across a surface. Measurements of '
-                                u'how the force varies',
-                    u'title': u'Friction'}, {
-                    u'id': u'209deb1f-1a46-4369-9e0d-18674cf58a3e@7',
-                    u'matches': u'1',
-                    u'rank': u'0.1',
-                    u'snippet': u'these special topic essays, macroscopic '
-                                u'phenomena (such as <span class="q-match">air'
-                                u'</span> pressure) are explained with '
-                                u'submicroscopic phenomena (such as atoms '
-                                u'bouncing',
-                    u'title': u'Preface'}, {
-                    u'id': u'c8bdbabc-62b1-4a5f-b291-982ab25756d7@6',
-                    u'matches': u'1',
-                    u'rank': u'0.1',
-                    u'snippet': u'construction, while distances in kilometers '
-                                u'are appropriate for <span class="q-match">'
-                                u'air</span> travel, and the tiny measure of '
-                                u'nanometers are convenient in optical',
-                    u'title': u'Physical Quantities and Units'}, {
-                    u'id': u'ae3e18de-638d-4738-b804-dc69cd4db3a3@5',
-                    u'matches': u'1',
-                    u'rank': u'0.1',
-                    u'snippet': u'size 8{"ref"} } } {}\n                '
-                                u'\n            \n            coefficient of '
-                                u'performance for refrigerators and <span '
-                                u'class="q-match">air</span> conditioners'
-                                u'\n          \n          \n            '
-                                u'\n              \n                '
-                                u'\n                    \n          '
-                                u'            \n                        cos\n'
-                                u'                        \u03b8\n           '
-                                u'           \n                    \n        '
-                                u'            \n                  \n         '
-                                u'     \n                  \n                '
-                                u'    \n                      \n             '
-                                u'           cos\n                        '
-                                u'\u03b8\n                      \n           '
-                                u'         \n                    \n          '
-                                u'        \n                   size 12{"cos"'
-                                u'\u03b8} {}\n                \n            '
-                                u'\n            cosine',
-                    u'title': u'Glossary of Key Symbols and Notation'}],
-                u'query': {u'id': u'e79ffde3-7fb4-4af3-9ec8-df648b391597@7.1',
-                           u'search_term': u'air or liquid drag'},
-                u'total': 7}}
+        self.assertEqual(status, '200 OK')
+        self.assertEqual(content_type, 'application/json')
+        self.assertEqual(results, IN_BOOK_AND_SEARCH_RESULT)
+
+    def test_in_book_search_query_type_AND(self):
+        id = 'e79ffde3-7fb4-4af3-9ec8-df648b391597'
+        version = '7.1'
+
+        # build the request
+        self.request.matchdict = {'ident_hash': '{}@{}'.format(id, version)}
+        # search query param
+        self.request.params = {'q': 'air or liquid drag', 'query_type': 'AND'}
+        self.request.matched_route = mock.Mock()
+        self.request.matched_route.name = 'in-book-search'
+
+        from ...views.in_book_search import in_book_search
+        results = in_book_search(self.request).json_body
+        status = self.request.response.status
+        content_type = self.request.response.content_type
 
         self.assertEqual(status, '200 OK')
         self.assertEqual(content_type, 'application/json')
-        self.assertEqual(results, IN_BOOK_SEARCH_RESULT)
+        self.assertEqual(results, IN_BOOK_AND_SEARCH_RESULT)
+
+    def test_in_book_search_query_type_OR(self):
+        id = 'e79ffde3-7fb4-4af3-9ec8-df648b391597'
+        version = '7.1'
+
+        # build the request
+        self.request.matchdict = {'ident_hash': '{}@{}'.format(id, version)}
+        # search query param
+        self.request.params = {'q': 'air or liquid drag', 'query_type': 'OR'}
+        self.request.matched_route = mock.Mock()
+        self.request.matched_route.name = 'in-book-search'
+
+        from ...views.in_book_search import in_book_search
+        results = in_book_search(self.request).json_body
+        status = self.request.response.status
+        content_type = self.request.response.content_type
+
+        self.assertEqual(status, '200 OK')
+        self.assertEqual(content_type, 'application/json')
+        self.assertEqual(results, IN_BOOK_OR_SEARCH_RESULT)
 
     def test_in_book_search_highlighted_results_wo_version(self):
         book_uuid = 'e79ffde3-7fb4-4af3-9ec8-df648b391597'

--- a/cnxarchive/views/in_book_search.py
+++ b/cnxarchive/views/in_book_search.py
@@ -9,10 +9,8 @@
 import json
 import logging
 
-from pyramid.threadlocal import get_current_registry
 from pyramid.view import view_config
 
-from .. import config
 from ..database import SQL, db_connect
 from ..utils import (
     IdentHashShortId, IdentHashMissingVersion, split_ident_hash
@@ -40,6 +38,11 @@ def in_book_search(request):
     ident_hash = args['ident_hash']
 
     args['search_term'] = request.params.get('q', '')
+    query_type = request.params.get('query_type', '')
+    combiner = ''
+    if query_type:
+        if query_type.lower() == 'or':
+            combiner = '_or'
 
     id, version = split_ident_hash(ident_hash)
     args['uuid'] = id
@@ -53,7 +56,7 @@ def in_book_search(request):
                 statement = SQL['get-in-collated-book-search']
             else:
                 statement = SQL['get-in-book-search']
-            cursor.execute(statement, args)
+            cursor.execute(statement.format(combiner=combiner), args)
             res = cursor.fetchall()
 
             results['results'] = {'query': [],
@@ -99,6 +102,12 @@ def in_book_search_highlighted_results(request):
 
     args['search_term'] = request.params.get('q', '')
 
+    query_type = request.params.get('query_type', '')
+    combiner = ''
+    if query_type:
+        if query_type.lower() == 'or':
+            combiner = '_or'
+
     # Get version from URL params
     id, version = split_ident_hash(ident_hash)
     args['uuid'] = id
@@ -112,7 +121,7 @@ def in_book_search_highlighted_results(request):
                 statement = SQL['get-in-collated-book-search-full-page']
             else:
                 statement = SQL['get-in-book-search-full-page']
-            cursor.execute(statement, args)
+            cursor.execute(statement.format(combiner=combiner), args)
             res = cursor.fetchall()
 
             results['results'] = {'query': [],


### PR DESCRIPTION
Further discussion w/ QA leads me to believe that "OR" is not the best default for in book search. This provides a parameter to select the combining boolean, defaulting to "AND"
