### PR TITLE
Change utils and database code to be more py3 compatible

### DIFF
--- a/cnxarchive/database.py
+++ b/cnxarchive/database.py
@@ -468,7 +468,7 @@ def republish_module_trigger(plpy, td):
     plpy.log('modified: {}'.format(modified))
     plpy.log('insert values:\n{}\n'.format('\n'.join([
         '{}: {}'.format(key, value)
-        for key, value in td['new'].iteritems()])))
+        for key, value in td['new'].items()])))
 
     return modified
 

--- a/cnxarchive/utils/ident_hash.py
+++ b/cnxarchive/utils/ident_hash.py
@@ -120,7 +120,7 @@ class CNXHash(uuid.UUID):
     def __init__(self, uu=None, *args, **kwargs):
 
         if isinstance(uu, uuid.UUID):
-            uuid.UUID.__init__(self, bytes=uu.get_bytes())
+            uuid.UUID.__init__(self, bytes=uu.bytes)
         elif isinstance(uu, basestring):
             uuid.UUID.__init__(self, hex=uu)
         else:
@@ -141,7 +141,7 @@ class CNXHash(uuid.UUID):
             identifier = uuid.UUID(identifier)
         elif not(isinstance(identifier, uuid.UUID)):
             raise TypeError("must be uuid or string.")
-        identifier = base64.urlsafe_b64encode(identifier.get_bytes())
+        identifier = base64.urlsafe_b64encode(identifier.bytes)
         identifier = identifier.rstrip(cls._HASH_PADDING_CHAR)
         return identifier
 

--- a/cnxarchive/utils/ident_hash.py
+++ b/cnxarchive/utils/ident_hash.py
@@ -5,6 +5,7 @@
 # Public License version 3 (AGPLv3).
 # See LICENCE.txt for details.
 # ###
+import sys
 import uuid
 import base64
 
@@ -21,6 +22,10 @@ __all__ = (
     'split_legacy_hash',
     'CNXHash',
     )
+
+
+if sys.version_info >= (3,):
+    basestring = (str, bytes)
 
 
 class IdentHashError(Exception):
@@ -114,7 +119,7 @@ class CNXHash(uuid.UUID):
     FULLUUID = 2
     _SHORT_HASH_LENGTH = 8
     _MAX_SHORT_HASH_LENGTH = 22
-    _HASH_PADDING_CHAR = '='
+    _HASH_PADDING_CHAR = b'='
     _HASH_DUMMY_CHAR = '0'
 
     def __init__(self, uu=None, *args, **kwargs):


### PR DESCRIPTION
- Change dict .iteritems() to .items() in database.py

  Python 3 dicts don't have `.iteritems()` anymore, changing to `.items()`
  means that the code will work in python 2 and 3.  Since cnx-db tests
  are also running in python 3.5, cnxarchive needs to have some of the
  database code updated to be python 3 compatible.

- Change uuid `.get_bytes()` to `.bytes` in utils

  Python 3 uuid objects no longer has `.get_bytes()` but it seems `.bytes`
  does the same thing and exists in python 2 and 3, so changing the code
  to use that instead.

- Define basestring for python 3 in utils ident_hash

  `basestring` is `str` and `unicode` in python 2, the equivalent for
  python 3 would be `bytes` and `str`.

---

Created for Connexions/cnx-db#86