### PR TITLE
Wait for the archive container to be up in .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,9 @@ before_script:
   # Stop init_venv from doing anything
   - docker exec cnxarchive_db_1 /bin/bash -c "echo 'CREATE SCHEMA venv' | psql -U cnxarchive cnxarchive-testing"
 
+  # Wait for cnxarchive_archive_1 to be available
+  - while sleep 5; do docker ps -a; if [[ -n "`docker ps | grep cnxarchive_archive_1 | grep ' Up '`" ]]; then break; fi; done
+
   # Install packages needed for testing
   - docker exec cnxarchive_archive_1 /bin/bash -c "pip install --user coverage codecov"
 script:


### PR DESCRIPTION
There appears to be a race condition on travis:

```
$ docker exec cnxarchive_archive_1 /bin/bash -c "pip install --user coverage codecov"
Error response from daemon: Container 90b9f01437b8f1585fb315d15e0c0979678b943152fd6e1e8edf7b0149303d7c is not running
```

So add a `while sleep` loop to wait for the container to be up before trying to
execute stuff on it.