### PR TITLE
Set timeout on travis waiting for archive container to be up

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ before_script:
   - docker exec cnxarchive_db_1 /bin/bash -c "echo 'CREATE SCHEMA venv' | psql -U cnxarchive cnxarchive-testing"
 
   # Wait for cnxarchive_archive_1 to be available
-  - while sleep 5; do docker ps -a; if [[ -n "`docker ps | grep cnxarchive_archive_1 | grep ' Up '`" ]]; then break; fi; done
+  - timeout=0; while sleep 5; do ((timeout++)); if [[ $timeout -gt 10 ]]; then break; fi; docker ps -a; if [[ -n "`docker ps | grep cnxarchive_archive_1 | grep ' Up '`" ]]; then break; fi; done; if [[ $timeout -gt 10 ]]; then false; fi
 
   # Install packages needed for testing
   - docker exec cnxarchive_archive_1 /bin/bash -c "pip install --user coverage codecov"

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ install:
   - docker-compose -f .travis-compose.yml up -d
 before_script:
   # wait for postgres to be available
-  - while ! echo | psql 'user=postgres host=localhost port=5433'; do docker logs cnxarchive_db_1 | tail; sleep 5; done
+  - timeout=0; while ! echo | psql 'user=postgres host=localhost port=5433'; do ((timeout++)); if [[ $timeout -gt 10 ]]; then break; fi; docker logs cnxarchive_db_1 | tail; sleep 5; done; if [[ $timeout -gt 10 ]]; then false; fi
 
   # Give cnxarchive superuser privileges on postgres
   - docker exec cnxarchive_db_1 /bin/bash -c "echo 'ALTER USER cnxarchive WITH SUPERUSER' | psql -U postgres postgres"


### PR DESCRIPTION
A check was added to .travis.yml for waiting for the archive container
to be available, but if the archive container exited for whatever
reason, this loop will run forever and not ever timeout.  We don't
really expect the container to take that long to be available, so the
timeout is set to ~1 minute.

---

As you can see, I've improved the "waiting for archive to be up" bit so it will now timeout and fail the build: https://travis-ci.org/Connexions/cnx-archive/builds/299331685#L2601