### PR TITLE
Adjust travis config to give cnxarchive role login perms

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ before_script:
   - while ! echo | psql 'user=postgres host=localhost port=5433'; do docker logs cnxarchive_db_1 | tail; sleep 5; done
 
   # Give cnxarchive superuser privileges on postgres
-  - docker exec cnxarchive_db_1 /bin/bash -c "echo 'ALTER USER cnxarchive WITH SUPERUSER' | psql -U postgres postgres"
+  - docker exec cnxarchive_db_1 /bin/bash -c "echo 'ALTER USER cnxarchive WITH LOGIN SUPERUSER' | psql -U postgres postgres"
   # Stop init_venv from doing anything
   - docker exec cnxarchive_db_1 /bin/bash -c "echo 'CREATE SCHEMA venv' | psql -U cnxarchive cnxarchive-testing"
 


### PR DESCRIPTION
I'm not sure why this is necessary now when it wasn't before, but it does make it so the master is passing tests again.