### PR TITLE
Fix travis tests from modification to the cnx-db container

### DIFF
--- a/.travis-compose.yml
+++ b/.travis-compose.yml
@@ -17,10 +17,10 @@ services:
     ports:
       - "5433:5432"
     environment:
-      - DB_USER=cnxarchive
-      - DB_NAME=cnxarchive-testing
-      - DB_URL=postgresql://cnxarchive@localhost/cnxarchive-testing
-      - DB_SUPER_URL=postgresql://postgres@localhost/cnxarchive-testing
+      - "DB_USER=cnxarchive"
+      - "POSTGRES_DB=cnxarchive-testing"
+      - "DB_URL=postgresql://cnxarchive@localhost/cnxarchive-testing"
+      - "DB_SUPER_URL=postgresql://postgres@localhost/cnxarchive-testing"
   memcached:
     image: memcached:1.5
     ports:

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ script:
   # This is the same as `python -m unittest discover` with a coverage wrapper.
   #- coverage run --source=cnxarchive setup.py test
   - docker exec cnxarchive_archive_1 /bin/bash -c "cd /src; TESTING_CONFIG=cnxarchive/tests/.travis-testing.ini coverage run --source=cnxarchive setup.py test"
-  - docker-compose down
+  - docker-compose -f .travis-compose.yml down
 after_success:
   # Report test coverage to codecov.io
   - docker exec cnxarchive_archive_1 /bin/bash -c "codecov"

--- a/cnxarchive/tests/views/views_test_data.py
+++ b/cnxarchive/tests/views/views_test_data.py
@@ -79,6 +79,7 @@ COLLECTION_METADATA = {
     u'mediaType': u'application/vnd.org.cnx.collection',
     u'version': u'7.1',
     u'printStyle': None,
+    u'baked': None,
     u'googleAnalytics': u'UA-XXXXX-Y',
     u'buyLink': None,
     u'legacy_id': u'col11406',
@@ -240,6 +241,7 @@ COLLECTION_DERIVED_METADATA = {
 }
 MODULE_METADATA = {
     u'printStyle': None,
+    u'baked': None,
     u'roles': None,
     u'subjects': [u'Science and Technology'],
     u'abstract': None,

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,9 +12,7 @@ services:
     ports:
       - "5432"
     volumes:
-      # slim database dump
       # https://github.com/Connexions/devops/wiki/How-To%3A-Get-a-Slim-Database-Dump
-      - ./cnxarchive_dump.tar:/tmp/cnxarchive_dump.tar:ro
   memcached:
     image: memcached:1.5
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,7 @@ services:
     build: https://github.com/Connexions/cnx-db.git
     ports:
       - "5432"
-    volumes:
+#    volumes:
       # https://github.com/Connexions/devops/wiki/How-To%3A-Get-a-Slim-Database-Dump
   memcached:
     image: memcached:1.5


### PR DESCRIPTION
We modified the cnx-db container so that it now requires the `POSTGRES_DB` environment variable be defined when the database isn't `repository`, which it isn't in the case of tests within this repository.

The quotations around the environment variables are because it didn't work otherwise. I didn't look into it to much, but it's likely because the value has a `-` in it that flubs up the yaml parser.