### PR TITLE
WIP: Changed the short id redirect from HTTPFound to HTTPMovedPermanently

### DIFF
--- a/cnxarchive/tests/test_functional.py
+++ b/cnxarchive/tests/test_functional.py
@@ -86,7 +86,7 @@ class IdentHashShortIdTestCase(testing.FunctionalTestCase):
 
         for ext in self.contents_extensions:
             resp = self.testapp.get('/contents/{}@8{}'.format(short_id, ext))
-            self.assertEqual(resp.status, '302 Found')
+            self.assertEqual(resp.status, '301 Moved Permanently')
             self.assertEqual(
                 unquote(resp.location),
                 'http://localhost/contents/{}@8{}'.format(uuid, ext))
@@ -120,7 +120,7 @@ class IdentHashShortIdTestCase(testing.FunctionalTestCase):
             resp = self.testapp.get(
                 '/contents/{}@{}:{}@0{}'.format(
                     book_shortid, book_version, page_shortid, ext))
-            self.assertEqual(resp.status, '302 Found')
+            self.assertEqual(resp.status, '301 Moved Permanently')
             self.assertEqual(
                 unquote(resp.location),
                 'http://localhost/contents/{}@{}:{}@0{}'.format(
@@ -139,7 +139,7 @@ class IdentHashShortIdTestCase(testing.FunctionalTestCase):
         for ext in self.contents_extensions:
             resp = self.testapp.get('/contents/{}@{}:{}@{}{}'.format(
                 book_shortid, book_version, page_shortid, page_version, ext))
-            self.assertEqual(resp.status, '302 Found')
+            self.assertEqual(resp.status, '301 Moved Permanently')
             self.assertEqual(
                 unquote(resp.location),
                 'http://localhost/contents/{}@{}:{}@{}{}'.format(
@@ -192,7 +192,7 @@ class IdentHashShortIdTestCase(testing.FunctionalTestCase):
         version = '7.1'
 
         resp = self.testapp.get('/extras/{}@{}'.format(short_id, version))
-        self.assertEqual(resp.status, '302 Found')
+        self.assertEqual(resp.status, '301 Moved Permanently')
         self.assertEqual(
             unquote(resp.location),
             'http://localhost/extras/{}@{}'.format(uuid, version))
@@ -221,7 +221,7 @@ class IdentHashShortIdTestCase(testing.FunctionalTestCase):
 
         resp = self.testapp.get('/search/{}@{}?q=air'.format(
             short_id, version))
-        self.assertEqual(resp.status, '302 Found')
+        self.assertEqual(resp.status, '301 Moved Permanently')
         self.assertEqual(
             unquote(resp.location),
             'http://localhost/search/{}@{}?q=air'.format(uuid, version))
@@ -272,7 +272,7 @@ class IdentHashShortIdTestCase(testing.FunctionalTestCase):
 
         resp = self.testapp.get('/search/{}@{}:{}?q=air'.format(
             book_short_id, book_version, page_short_id))
-        self.assertEqual(resp.status, '302 Found')
+        self.assertEqual(resp.status, '301 Moved Permanently')
         self.assertEqual(
             unquote(resp.location),
             'http://localhost/search/{}@{}:{}?q=air'.format(

--- a/cnxarchive/tests/views/test_legacy_redirect.py
+++ b/cnxarchive/tests/views/test_legacy_redirect.py
@@ -86,10 +86,10 @@ class LegacyRedirectViewsTestCase(unittest.TestCase):
         from ...views.legacy_redirect import redirect_legacy_content
 
         # Check that the view redirects to the new url, latest version
-        with self.assertRaises(httpexceptions.HTTPFound) as cm:
+        with self.assertRaises(httpexceptions.HTTPMovedPermanently) as cm:
             redirect_legacy_content(self.request)
 
-        self.assertEqual(cm.exception.status, '302 Found')
+        self.assertEqual(cm.exception.status, '301 Moved Permanently')
         self.assertEqual(cm.exception.headers['Location'],
                          quote('/contents/{}@5'.format(uuid)))
 
@@ -106,10 +106,10 @@ class LegacyRedirectViewsTestCase(unittest.TestCase):
         from ...views.legacy_redirect import redirect_legacy_content
 
         # Check that the view redirects to the new url, latest version
-        with self.assertRaises(httpexceptions.HTTPFound) as cm:
+        with self.assertRaises(httpexceptions.HTTPMovedPermanently) as cm:
             redirect_legacy_content(self.request)
 
-        self.assertEqual(cm.exception.status, '302 Found')
+        self.assertEqual(cm.exception.status, '301 Moved Permanently')
         self.assertEqual(cm.exception.headers['Location'],
                          quote('/contents/{}@5'.format(uuid)))
 
@@ -151,10 +151,10 @@ class LegacyRedirectViewsTestCase(unittest.TestCase):
         from ...views.legacy_redirect import redirect_legacy_content
 
         # Check that the view redirects to the new url, old version
-        with self.assertRaises(httpexceptions.HTTPFound) as cm:
+        with self.assertRaises(httpexceptions.HTTPMovedPermanently) as cm:
             redirect_legacy_content(self.request)
 
-        self.assertEqual(cm.exception.status, '302 Found')
+        self.assertEqual(cm.exception.status, '301 Moved Permanently')
         self.assertEqual(cm.exception.headers['Location'],
                          quote('/contents/{}@4'.format(uuid)))
 
@@ -191,10 +191,10 @@ class LegacyRedirectViewsTestCase(unittest.TestCase):
         from ...views.legacy_redirect import redirect_legacy_content
 
         # Check that the view redirects to the new url, old version
-        with self.assertRaises(httpexceptions.HTTPFound) as cm:
+        with self.assertRaises(httpexceptions.HTTPMovedPermanently) as cm:
             redirect_legacy_content(self.request)
 
-        self.assertEqual(cm.exception.status, '302 Found')
+        self.assertEqual(cm.exception.status, '301 Moved Permanently')
         self.assertEqual(
             cm.exception.headers['Location'],
             quote('/contents/{}@1.1:{}'.format(book_uuid, page_uuid)))
@@ -213,10 +213,10 @@ class LegacyRedirectViewsTestCase(unittest.TestCase):
         from ...views.legacy_redirect import redirect_legacy_content
 
         # Check that the view redirects to the new url, old version
-        with self.assertRaises(httpexceptions.HTTPFound) as cm:
+        with self.assertRaises(httpexceptions.HTTPMovedPermanently) as cm:
             redirect_legacy_content(self.request)
 
-        self.assertEqual(cm.exception.status, '302 Found')
+        self.assertEqual(cm.exception.status, '301 Moved Permanently')
         self.assertEqual(cm.exception.headers['Location'],
                          quote('/contents/{}@4'.format(uuid)))
 
@@ -238,10 +238,10 @@ class LegacyRedirectViewsTestCase(unittest.TestCase):
         from ...views.legacy_redirect import redirect_legacy_content
 
         # Check that the view redirects to the resources url
-        with self.assertRaises(httpexceptions.HTTPFound) as cm:
+        with self.assertRaises(httpexceptions.HTTPMovedPermanently) as cm:
             redirect_legacy_content(self.request)
 
-        self.assertEqual(cm.exception.status, '302 Found')
+        self.assertEqual(cm.exception.status, '301 Moved Permanently')
         self.assertEqual(cm.exception.headers['Location'],
                          quote('/resources/{}/{}'.format(sha1, filename)))
 

--- a/cnxarchive/views/exceptions.py
+++ b/cnxarchive/views/exceptions.py
@@ -57,7 +57,7 @@ def ident_hash_short_id(exc, request):
     route_name = request.matched_route.name
     route_args = request.matchdict.copy()
     route_args['ident_hash'] = join_ident_hash(uuid_, exc.version)
-    return httpexceptions.HTTPFound(request.route_path(
+    return httpexceptions.HTTPMovedPermanently(request.route_path(
         route_name, _query=request.params, **route_args))
 
 

--- a/cnxarchive/views/legacy_redirect.py
+++ b/cnxarchive/views/legacy_redirect.py
@@ -89,9 +89,10 @@ def redirect_legacy_content(request):
                 try:
                     res = cursor.fetchone()
                     resourceid = res[0]
-                    raise httpexceptions.HTTPFound(request.route_path(
-                        'resource', hash=resourceid,
-                        ignore=u'/{}'.format(filename)))
+                    raise httpexceptions.HTTPMovedPermanently(
+                         request.route_path(
+                            'resource', hash=resourceid,
+                            ignore=u'/{}'.format(filename)))
                 except TypeError:  # None returned
                     raise httpexceptions.HTTPNotFound()
 
@@ -104,5 +105,5 @@ def redirect_legacy_content(request):
             id, ident_hash = \
                 _get_page_in_book(id, version, book_uuid, book_version)
 
-    raise httpexceptions.HTTPFound(
+    raise httpexceptions.HTTPMovedPermanently(
         request.route_path('content', ident_hash=ident_hash))


### PR DESCRIPTION
It was discovered that Google Search may not be indexing the pages on cnx due to the code we are using when redirecting from the legacy uuid to to the short id. This fix makes a change to the code from 302 to 301 in order to increase our googlebot friendliness. 