### PR TITLE
Restore a /robots.txt route. Returns do not index robots.txt

### DIFF
--- a/cnxarchive/__init__.py
+++ b/cnxarchive/__init__.py
@@ -72,6 +72,7 @@ def declare_api_routes(config):
     add_route('extras', '/extras')  # cnxarchive.views:extras
     add_route('sitemap-index', '/sitemap_index.xml')  # noqa cnxarchive.views:sitemap
     add_route('sitemap', '/sitemap-{from_id}.xml')  # noqa cnxarchive.views:sitemap
+    add_route('robots', '/robots.txt')  # noqa cnxarchive.views:robots
     add_route('legacy-redirect', '/content/{objid}{ignore:(/)?}')  # noqa cnxarchive.views:redirect_legacy_content
     add_route('legacy-redirect-latest', '/content/{objid}/latest{ignore:(/)?}{filename:(.+)?}')  # noqa cnxarchive.views:redirect_legacy_content
     add_route('legacy-redirect-w-version', '/content/{objid}/{objver}{ignore:(/)?}{filename:(.+)?}')  # noqa cnxarchive.views:redirect_legacy_content

--- a/cnxarchive/tests/views/test_robots.py
+++ b/cnxarchive/tests/views/test_robots.py
@@ -1,0 +1,66 @@
+# -*- coding: utf-8 -*-
+# ###
+# Copyright (c) 2013, Rice University
+# This software is subject to the provisions of the GNU Affero General
+# Public License version 3 (AGPLv3).
+# See LICENCE.txt for details.
+# ###
+import unittest
+
+try:
+    from unittest import mock
+except ImportError:
+    import mock
+
+from pyramid import testing as pyramid_testing
+
+from .. import testing
+
+
+class RobotsViewsTestCase(unittest.TestCase):
+    fixture = testing.data_fixture
+    maxDiff = 10000
+
+    @classmethod
+    def setUpClass(cls):
+        cls.settings = testing.integration_test_settings()
+
+    @testing.db_connect
+    def setUp(self, cursor):
+        self.fixture.setUp()
+        self.request = pyramid_testing.DummyRequest()
+        self.request.headers['HOST'] = 'cnx.org'
+        self.request.application_url = 'http://cnx.org'
+        config = pyramid_testing.setUp(settings=self.settings,
+                                       request=self.request)
+
+        # Set up routes
+        from ... import declare_api_routes
+        declare_api_routes(config)
+
+        # Set up type info
+        from ... import declare_type_info
+        declare_type_info(config)
+
+    def tearDown(self):
+        pyramid_testing.tearDown()
+        self.fixture.tearDown()
+
+    def test_robots(self):
+        self.request.matched_route = mock.Mock()
+        self.request.matched_route.name = 'robots'
+
+        # Call the view
+        from ...views.robots import robots
+        robots = robots(self.request).body
+
+        # Check the headers
+        resp = self.request.response
+        self.assertEqual(resp.content_type, 'text/plain')
+
+        # Check robots.txt content
+        expected_text = """
+User-Agent: *
+Disallow: /
+"""
+        self.assertMultiLineEqual(robots, expected_text)

--- a/cnxarchive/views/robots.py
+++ b/cnxarchive/views/robots.py
@@ -1,0 +1,23 @@
+# -*- coding: utf-8 -*-
+# ###
+# Copyright (c) 2013, Rice University
+# This software is subject to the provisions of the GNU Affero General
+# Public License version 3 (AGPLv3).
+# See LICENCE.txt for details.
+# ###
+"""View robots.txt page."""
+from pyramid.view import view_config
+
+
+@view_config(route_name='robots', request_method='GET')
+def robots(request):
+    """Return a simple "don't index me" robots.txt file."""
+
+    resp = request.response
+    resp.status = '200 OK'
+    resp.content_type = 'text/plain'
+    resp.body = """
+User-Agent: *
+Disallow: /
+"""
+    return resp


### PR DESCRIPTION
As an API server, it isn't needed or proper for search engines to index the archive.cnx.org urls out there. Adding a default "don't index me" route, so that no matter how archive is deployed, we'll fall back to this control file. Note that in production, the  top level human-facing urls robots.txt file is contructed at deployment time, and served as a static file.