### PR TITLE
WIP: Updated db service in docker-compose to use openstax cnx-db image

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       - db
       - memcached
   db:
-    build: https://github.com/Connexions/cnx-db.git
+    image: openstax/cnx-db:1.5.1
     ports:
       - "5432"
 #    volumes:


### PR DESCRIPTION
* The internal port binding was not working when using the build file from the git repository so using the image may be a better way to do this.