### PR TITLE
moving formatted authors

### DIFF
--- a/cnxarchive/views/content.py
+++ b/cnxarchive/views/content.py
@@ -238,6 +238,7 @@ def get_books_containing_page(uuid, version):
                            {'document_uuid': uuid,
                             'document_version': version})
             results = cursor.fetchall()
+            formatAuthors(results)
     return results
 
 # ######### #
@@ -296,7 +297,6 @@ def get_extra(request):
             results['canPublish'] = get_module_can_publish(cursor, id)
             results['state'] = get_state(cursor, id, version)
             results['books'] = get_books_containing_page(id, version)
-            formatAuthors(results['books'])
 
     resp = request.response
     resp.content_type = 'application/json'


### PR DESCRIPTION
just moving where the authors are formatted because so webview can get the formatted author correctly. moving to `get_books_containing_page function` from `get_extra`

fixup to PR https://github.com/Connexions/cnx-archive/pull/550