### PR TITLE
Fix the docker container build to use the base python container

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,22 +13,22 @@ install:
   - docker-compose -f .travis-compose.yml up -d
 before_script:
   # wait for postgres to be available
-  - while ! echo | psql 'user=postgres host=localhost port=5433'; do docker logs cnxarchive_db_1 | tail; sleep 5; done
+  - while ! echo | psql 'user=postgres host=localhost port=5433'; do docker-compose -f .travis-compose.yml logs db | tail; sleep 5; done
 
   # Give cnxarchive superuser privileges on postgres
-  - docker exec cnxarchive_db_1 /bin/bash -c "echo 'ALTER USER cnxarchive WITH LOGIN SUPERUSER' | psql -U postgres postgres"
+  - docker-compose -f .travis-compose.yml exec db /bin/bash -c "echo 'ALTER USER cnxarchive WITH LOGIN SUPERUSER' | psql -U postgres postgres"
   # Stop init_venv from doing anything
-  - docker exec cnxarchive_db_1 /bin/bash -c "echo 'CREATE SCHEMA venv' | psql -U cnxarchive cnxarchive-testing"
+  - docker-compose -f .travis-compose.yml exec db /bin/bash -c "echo 'CREATE SCHEMA venv' | psql -U cnxarchive cnxarchive-testing"
 
   # Wait for cnxarchive_archive_1 to be available
   - while sleep 5; do docker ps -a; if [[ -n "`docker ps | grep cnxarchive_archive_1 | grep ' Up '`" ]]; then break; fi; done
 
   # Install packages needed for testing
-  - docker exec cnxarchive_archive_1 /bin/bash -c "pip install --user coverage codecov"
+  - docker-compose -f .travis-compose.yml exec archive /bin/bash -c "pip install --user coverage codecov"
 script:
   # This is the same as `python -m unittest discover` with a coverage wrapper.
   #- coverage run --source=cnxarchive setup.py test
-  - docker exec cnxarchive_archive_1 /bin/bash -c "cd /src; TESTING_CONFIG=cnxarchive/tests/.travis-testing.ini coverage run --source=cnxarchive setup.py test"
+  - docker-compose -f .travis-compose.yml exec archive /bin/bash -c "cd /src; TESTING_CONFIG=cnxarchive/tests/.travis-testing.ini coverage run --source=cnxarchive setup.py test"
   - docker-compose -f .travis-compose.yml down
 after_success:
   # Report test coverage to codecov.io

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:16.04
+FROM python:2.7-jessie
 
 RUN addgroup --system archive \
     && adduser --system --group archive
@@ -9,15 +9,12 @@ RUN apt-get update && apt-get install -y \
     libxslt-dev \
     git \
     make \
-    python2.7 \
-    python2.7-dev \
-    python-pip \
     pkg-config \
     gcc \
     zlib1g-dev \
     wget \
     tzdata \
- && rm -rf /var/lib/apt/lists/*
+    && rm -rf /var/lib/apt/lists/*
 
 COPY . /src/
 WORKDIR /src/
@@ -34,9 +31,12 @@ ENV ARCHIVE_REQUIREMENTS ${ARCHIVE_REQUIREMENTS:-https://raw.githubusercontent.c
 RUN wget -O archive-requirements.txt $ARCHIVE_REQUIREMENTS
 
 USER archive
-RUN pip install --upgrade pip
-RUN pip install --no-cache-dir --user -r archive-requirements.txt
-RUN pip install --no-cache-dir --user -e .
+# See also https://github.com/pypa/pip/issues/5221
+RUN wget -O get-pip.py https://bootstrap.pypa.io/get-pip.py \
+    && python get-pip.py --user \
+    && rm get-pip.py
+RUN python -m pip install --no-cache-dir --user -r archive-requirements.txt
+RUN python -m pip install --no-cache-dir --user -e .
 
 ENV PATH $PATH:/home/archive/.local/bin
 


### PR DESCRIPTION
This upgrades pip by installing it as a local user installation. We no longer use the system package (python-pip) since it has an issue upgrading.

And I've made a simple adjustment in the travis config to call the generated container, whatever it's name might be rather than hard-coding to the exact name.

This corrects the failing tests on master.