### PR TITLE
fix reporting codecov, like other docker calls

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,6 +32,6 @@ script:
   - docker-compose -f .travis-compose.yml down
 after_success:
   # Report test coverage to codecov.io
-  - docker exec cnxarchive_archive_1 /bin/bash -c "codecov"
+  - docker-compose -f .travis-compose.yml exec archive /bin/bash -c "codecov"
 notifications:
   email: false


### PR DESCRIPTION
ibid - one instance of cnxarchive_archive_1 got missed