### PR TITLE
Build sitemap without stripping special chars to match Webview url

### DIFF
--- a/cnxarchive/tests/data/sitemap-OpenStaxCollege.xml
+++ b/cnxarchive/tests/data/sitemap-OpenStaxCollege.xml
@@ -1,67 +1,67 @@
 <?xml version='1.0' encoding='utf-8'?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
-    <loc>http://cnx.org/contents/a733d0d2-de9b-43f9-8aa9-f0895036899e@1.1/span-style-color-red-derived-span-copy-of-college-i-physics-i</loc>
+    <loc>http://cnx.org/contents/a733d0d2-de9b-43f9-8aa9-f0895036899e@1.1/-span-style-color-red-Derived-span-Copy-of-College-i-Physics-i-</loc>
     <lastmod>2013-08-31</lastmod>
   </url>
   <url>
-    <loc>http://cnx.org/contents/ae3e18de-638d-4738-b804-dc69cd4db3a3@5/glossary-of-key-symbols-and-notation</loc>
+    <loc>http://cnx.org/contents/ae3e18de-638d-4738-b804-dc69cd4db3a3@5/Glossary-of-Key-Symbols-and-Notation</loc>
     <lastmod>2013-08-31</lastmod>
   </url>
   <url>
-    <loc>http://cnx.org/contents/c0a76659-c311-405f-9a99-15c71af39325@5/useful-inf-rmation</loc>
+    <loc>http://cnx.org/contents/c0a76659-c311-405f-9a99-15c71af39325@5/Useful-Inf%C3%B8rmation</loc>
     <lastmod>2013-07-31</lastmod>
   </url>
   <url>
-    <loc>http://cnx.org/contents/7250386b-14a7-41a2-b8bf-9e9ab872f0dc@2/selected-radioactive-isotopes</loc>
+    <loc>http://cnx.org/contents/7250386b-14a7-41a2-b8bf-9e9ab872f0dc@2/Selected-Radioactive-Isotopes</loc>
     <lastmod>2013-07-31</lastmod>
   </url>
   <url>
-    <loc>http://cnx.org/contents/f6024d8a-1868-44c7-ab65-45419ef54881@3/atomic-masses</loc>
+    <loc>http://cnx.org/contents/f6024d8a-1868-44c7-ab65-45419ef54881@3/Atomic-Masses</loc>
     <lastmod>2013-07-31</lastmod>
   </url>
   <url>
-    <loc>http://cnx.org/contents/56f1c5c1-4014-450d-a477-2121e276beca@8/elasticity-stress-and-strain</loc>
+    <loc>http://cnx.org/contents/56f1c5c1-4014-450d-a477-2121e276beca@8/Elasticity-Stress-and-Strain</loc>
     <lastmod>2013-07-31</lastmod>
   </url>
   <url>
-    <loc>http://cnx.org/contents/26346a42-84b9-48ad-9f6a-62303c16ad41@6/drag-forces</loc>
+    <loc>http://cnx.org/contents/26346a42-84b9-48ad-9f6a-62303c16ad41@6/Drag-Forces</loc>
     <lastmod>2013-07-31</lastmod>
   </url>
   <url>
-    <loc>http://cnx.org/contents/ea271306-f7f2-46ac-b2ec-1d80ff186a59@5/friction</loc>
+    <loc>http://cnx.org/contents/ea271306-f7f2-46ac-b2ec-1d80ff186a59@5/Friction</loc>
     <lastmod>2013-07-31</lastmod>
   </url>
   <url>
-    <loc>http://cnx.org/contents/24a2ed13-22a6-47d6-97a3-c8aa8d54ac6d@2/introduction-further-applications-of-newton-s-laws</loc>
+    <loc>http://cnx.org/contents/24a2ed13-22a6-47d6-97a3-c8aa8d54ac6d@2/Introduction-Further-Applications-of-Newton-s-Laws</loc>
     <lastmod>2013-07-31</lastmod>
   </url>
   <url>
-    <loc>http://cnx.org/contents/5838b105-41cd-4c3d-a957-3ac004a48af3@5/approximation</loc>
+    <loc>http://cnx.org/contents/5838b105-41cd-4c3d-a957-3ac004a48af3@5/Approximation</loc>
     <lastmod>2013-07-31</lastmod>
   </url>
   <url>
-    <loc>http://cnx.org/contents/5152cea8-829a-4aaf-bcc5-c58a416ecb66@7/accuracy-precision-and-significant-figures</loc>
+    <loc>http://cnx.org/contents/5152cea8-829a-4aaf-bcc5-c58a416ecb66@7/Accuracy-Precision-and-Significant-Figures</loc>
     <lastmod>2013-07-31</lastmod>
   </url>
   <url>
-    <loc>http://cnx.org/contents/c8bdbabc-62b1-4a5f-b291-982ab25756d7@6/physical-quantities-and-units</loc>
+    <loc>http://cnx.org/contents/c8bdbabc-62b1-4a5f-b291-982ab25756d7@6/Physical-Quantities-and-Units</loc>
     <lastmod>2013-07-31</lastmod>
   </url>
   <url>
-    <loc>http://cnx.org/contents/d395b566-5fe3-4428-bcb2-19016e3aa3ce@4/physics-an-introduction</loc>
+    <loc>http://cnx.org/contents/d395b566-5fe3-4428-bcb2-19016e3aa3ce@4/Physics-An-Introduction</loc>
     <lastmod>2013-07-31</lastmod>
   </url>
   <url>
-    <loc>http://cnx.org/contents/f3c9ab70-a916-4d8c-9256-42953287b4e9@3/introduction-to-science-and-the-realm-of-physics-physical-quantities-and-units</loc>
+    <loc>http://cnx.org/contents/f3c9ab70-a916-4d8c-9256-42953287b4e9@3/Introduction-to-Science-and-the-Realm-of-Physics-Physical-Quantities-and-Units</loc>
     <lastmod>2013-07-31</lastmod>
   </url>
   <url>
-    <loc>http://cnx.org/contents/209deb1f-1a46-4369-9e0d-18674cf58a3e@7/preface-to-college-physics</loc>
+    <loc>http://cnx.org/contents/209deb1f-1a46-4369-9e0d-18674cf58a3e@7/Preface-to-College-Physics</loc>
     <lastmod>2013-07-31</lastmod>
   </url>
   <url>
-    <loc>http://cnx.org/contents/e79ffde3-7fb4-4af3-9ec8-df648b391597@7.1/college-physics</loc>
+    <loc>http://cnx.org/contents/e79ffde3-7fb4-4af3-9ec8-df648b391597@7.1/College-Physics</loc>
     <lastmod>2013-08-31</lastmod>
   </url>
 </urlset>

--- a/cnxarchive/tests/data/sitemap-OpenStaxCollege.xml
+++ b/cnxarchive/tests/data/sitemap-OpenStaxCollege.xml
@@ -1,7 +1,7 @@
 <?xml version='1.0' encoding='utf-8'?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
-    <loc>http://cnx.org/contents/a733d0d2-de9b-43f9-8aa9-f0895036899e@1.1/-span-style-color-red-Derived-span-Copy-of-College-i-Physics-i-</loc>
+    <loc>http://cnx.org/contents/a733d0d2-de9b-43f9-8aa9-f0895036899e@1.1/span-style-color-red-Derived-span-Copy-of-College-i-Physics-i</loc>
     <lastmod>2013-08-31</lastmod>
   </url>
   <url>

--- a/cnxarchive/tests/data/sitemap-Rasmus1975.xml
+++ b/cnxarchive/tests/data/sitemap-Rasmus1975.xml
@@ -1,7 +1,7 @@
 <?xml version='1.0' encoding='utf-8'?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
-    <loc>http://cnx.org/contents/91cb5f28-2b8a-4324-9373-dac1d617bc24@1/indk-b</loc>
+    <loc>http://cnx.org/contents/91cb5f28-2b8a-4324-9373-dac1d617bc24@1/Indk%C3%B8b</loc>
     <lastmod>2011-10-05</lastmod>
   </url>
 </urlset>

--- a/cnxarchive/tests/data/sitemap.xml
+++ b/cnxarchive/tests/data/sitemap.xml
@@ -1,7 +1,7 @@
 <?xml version='1.0' encoding='utf-8'?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
-    <loc>http://cnx.org/contents/91cb5f28-2b8a-4324-9373-dac1d617bc24@1/indkøb</loc>
+    <loc>http://cnx.org/contents/e79ffde3-7fb4-4af3-9ec8-df648b391597@7.1/college-physics</loc>
     <lastmod>2011-10-05</lastmod>
   </url>
   <url>

--- a/cnxarchive/tests/data/sitemap.xml
+++ b/cnxarchive/tests/data/sitemap.xml
@@ -5,7 +5,7 @@
     <lastmod>2011-10-05</lastmod>
   </url>
   <url>
-    <loc>http://cnx.org/contents/a733d0d2-de9b-43f9-8aa9-f0895036899e@1.1/-span-style-color-red-Derived-span-Copy-of-College-i-Physics-i-</loc>
+    <loc>http://cnx.org/contents/a733d0d2-de9b-43f9-8aa9-f0895036899e@1.1/span-style-color-red-Derived-span-Copy-of-College-i-Physics-i</loc>
     <lastmod>2013-08-31</lastmod>
   </url>
   <url>

--- a/cnxarchive/tests/data/sitemap.xml
+++ b/cnxarchive/tests/data/sitemap.xml
@@ -1,12 +1,20 @@
 <?xml version='1.0' encoding='utf-8'?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
-    <loc>http://cnx.org/contents/91cb5f28-2b8a-4324-9373-dac1d617bc24@1/indk-b</loc>
+    <loc>http://cnx.org/contents/91cb5f28-2b8a-4324-9373-dac1d617bc24@1/indkøb</loc>
     <lastmod>2011-10-05</lastmod>
   </url>
   <url>
-    <loc>http://cnx.org/contents/a733d0d2-de9b-43f9-8aa9-f0895036899e@1.1/span-style-color-red-derived-span-copy-of-college-i-physics-i</loc>
+    <loc>http://cnx.org/contents/a733d0d2-de9b-43f9-8aa9-f0895036899e@1.1/span-stylecolorredderivedspan-copy-of-college-i-physics-i</loc>
     <lastmod>2013-08-31</lastmod>
+  </url>
+  <url>
+    <loc>http://cnx.org/contents/ae3e18de-638d-4738-b804-dc69cd4db3a3@5/glossary-of-key-symbols-and-notation</loc>
+    <lastmod>2013-08-31</lastmod>
+  </url>
+  <url>
+    <loc>http://cnx.org/contents/c0a76659-c311-405f-9a99-15c71af39325@5/useful-inførmation</loc>
+    <lastmod>2013-07-31</lastmod>
   </url>
   <url>
     <loc>http://cnx.org/contents/ae3e18de-638d-4738-b804-dc69cd4db3a3@5/glossary-of-key-symbols-and-notation</loc>
@@ -29,7 +37,7 @@
     <lastmod>2013-07-31</lastmod>
   </url>
   <url>
-    <loc>http://cnx.org/contents/26346a42-84b9-48ad-9f6a-62303c16ad41@6/drag-forces</loc>
+    <loc>http://cnx.org/contents/24a2ed13-22a6-47d6-97a3-c8aa8d54ac6d@2/introduction-further-applications-of-newtons-laws</loc>
     <lastmod>2013-07-31</lastmod>
   </url>
   <url>
@@ -45,11 +53,11 @@
     <lastmod>2013-07-31</lastmod>
   </url>
   <url>
-    <loc>http://cnx.org/contents/5152cea8-829a-4aaf-bcc5-c58a416ecb66@7/accuracy-precision-and-significant-figures</loc>
+    <loc>http://cnx.org/contents/d395b566-5fe3-4428-bcb2-19016e3aa3ce@4/physics:-an-introduction</loc>
     <lastmod>2013-07-31</lastmod>
   </url>
   <url>
-    <loc>http://cnx.org/contents/c8bdbabc-62b1-4a5f-b291-982ab25756d7@6/physical-quantities-and-units</loc>
+    <loc>http://cnx.org/contents/f3c9ab70-a916-4d8c-9256-42953287b4e9@3/introduction-to-science-and-the-realm-of-physics,-physical-quantities,-and-units</loc>
     <lastmod>2013-07-31</lastmod>
   </url>
   <url>

--- a/cnxarchive/tests/data/sitemap.xml
+++ b/cnxarchive/tests/data/sitemap.xml
@@ -1,79 +1,71 @@
 <?xml version='1.0' encoding='utf-8'?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
-    <loc>http://cnx.org/contents/e79ffde3-7fb4-4af3-9ec8-df648b391597@7.1/college-physics</loc>
+    <loc>http://cnx.org/contents/91cb5f28-2b8a-4324-9373-dac1d617bc24@1/Indk%C3%B8b</loc>
     <lastmod>2011-10-05</lastmod>
   </url>
   <url>
-    <loc>http://cnx.org/contents/a733d0d2-de9b-43f9-8aa9-f0895036899e@1.1/span-stylecolorredderivedspan-copy-of-college-i-physics-i</loc>
+    <loc>http://cnx.org/contents/a733d0d2-de9b-43f9-8aa9-f0895036899e@1.1/-span-style-color-red-Derived-span-Copy-of-College-i-Physics-i-</loc>
     <lastmod>2013-08-31</lastmod>
   </url>
   <url>
-    <loc>http://cnx.org/contents/ae3e18de-638d-4738-b804-dc69cd4db3a3@5/glossary-of-key-symbols-and-notation</loc>
+    <loc>http://cnx.org/contents/ae3e18de-638d-4738-b804-dc69cd4db3a3@5/Glossary-of-Key-Symbols-and-Notation</loc>
     <lastmod>2013-08-31</lastmod>
   </url>
   <url>
-    <loc>http://cnx.org/contents/c0a76659-c311-405f-9a99-15c71af39325@5/useful-inførmation</loc>
+    <loc>http://cnx.org/contents/c0a76659-c311-405f-9a99-15c71af39325@5/Useful-Inf%C3%B8rmation</loc>
     <lastmod>2013-07-31</lastmod>
   </url>
   <url>
-    <loc>http://cnx.org/contents/ae3e18de-638d-4738-b804-dc69cd4db3a3@5/glossary-of-key-symbols-and-notation</loc>
-    <lastmod>2013-08-31</lastmod>
-  </url>
-  <url>
-    <loc>http://cnx.org/contents/c0a76659-c311-405f-9a99-15c71af39325@5/useful-inf-rmation</loc>
+    <loc>http://cnx.org/contents/7250386b-14a7-41a2-b8bf-9e9ab872f0dc@2/Selected-Radioactive-Isotopes</loc>
     <lastmod>2013-07-31</lastmod>
   </url>
   <url>
-    <loc>http://cnx.org/contents/7250386b-14a7-41a2-b8bf-9e9ab872f0dc@2/selected-radioactive-isotopes</loc>
+    <loc>http://cnx.org/contents/f6024d8a-1868-44c7-ab65-45419ef54881@3/Atomic-Masses</loc>
     <lastmod>2013-07-31</lastmod>
   </url>
   <url>
-    <loc>http://cnx.org/contents/f6024d8a-1868-44c7-ab65-45419ef54881@3/atomic-masses</loc>
+    <loc>http://cnx.org/contents/56f1c5c1-4014-450d-a477-2121e276beca@8/Elasticity-Stress-and-Strain</loc>
     <lastmod>2013-07-31</lastmod>
   </url>
   <url>
-    <loc>http://cnx.org/contents/56f1c5c1-4014-450d-a477-2121e276beca@8/elasticity-stress-and-strain</loc>
+    <loc>http://cnx.org/contents/26346a42-84b9-48ad-9f6a-62303c16ad41@6/Drag-Forces</loc>
     <lastmod>2013-07-31</lastmod>
   </url>
   <url>
-    <loc>http://cnx.org/contents/24a2ed13-22a6-47d6-97a3-c8aa8d54ac6d@2/introduction-further-applications-of-newtons-laws</loc>
+    <loc>http://cnx.org/contents/ea271306-f7f2-46ac-b2ec-1d80ff186a59@5/Friction</loc>
     <lastmod>2013-07-31</lastmod>
   </url>
   <url>
-    <loc>http://cnx.org/contents/ea271306-f7f2-46ac-b2ec-1d80ff186a59@5/friction</loc>
+    <loc>http://cnx.org/contents/24a2ed13-22a6-47d6-97a3-c8aa8d54ac6d@2/Introduction-Further-Applications-of-Newton-s-Laws</loc>
     <lastmod>2013-07-31</lastmod>
   </url>
   <url>
-    <loc>http://cnx.org/contents/24a2ed13-22a6-47d6-97a3-c8aa8d54ac6d@2/introduction-further-applications-of-newton-s-laws</loc>
+    <loc>http://cnx.org/contents/5838b105-41cd-4c3d-a957-3ac004a48af3@5/Approximation</loc>
     <lastmod>2013-07-31</lastmod>
   </url>
   <url>
-    <loc>http://cnx.org/contents/5838b105-41cd-4c3d-a957-3ac004a48af3@5/approximation</loc>
+    <loc>http://cnx.org/contents/5152cea8-829a-4aaf-bcc5-c58a416ecb66@7/Accuracy-Precision-and-Significant-Figures</loc>
     <lastmod>2013-07-31</lastmod>
   </url>
   <url>
-    <loc>http://cnx.org/contents/d395b566-5fe3-4428-bcb2-19016e3aa3ce@4/physics:-an-introduction</loc>
+    <loc>http://cnx.org/contents/c8bdbabc-62b1-4a5f-b291-982ab25756d7@6/Physical-Quantities-and-Units</loc>
     <lastmod>2013-07-31</lastmod>
   </url>
   <url>
-    <loc>http://cnx.org/contents/f3c9ab70-a916-4d8c-9256-42953287b4e9@3/introduction-to-science-and-the-realm-of-physics,-physical-quantities,-and-units</loc>
+    <loc>http://cnx.org/contents/d395b566-5fe3-4428-bcb2-19016e3aa3ce@4/Physics-An-Introduction</loc>
     <lastmod>2013-07-31</lastmod>
   </url>
   <url>
-    <loc>http://cnx.org/contents/d395b566-5fe3-4428-bcb2-19016e3aa3ce@4/physics-an-introduction</loc>
+    <loc>http://cnx.org/contents/f3c9ab70-a916-4d8c-9256-42953287b4e9@3/Introduction-to-Science-and-the-Realm-of-Physics-Physical-Quantities-and-Units</loc>
     <lastmod>2013-07-31</lastmod>
   </url>
   <url>
-    <loc>http://cnx.org/contents/f3c9ab70-a916-4d8c-9256-42953287b4e9@3/introduction-to-science-and-the-realm-of-physics-physical-quantities-and-units</loc>
+    <loc>http://cnx.org/contents/209deb1f-1a46-4369-9e0d-18674cf58a3e@7/Preface-to-College-Physics</loc>
     <lastmod>2013-07-31</lastmod>
   </url>
   <url>
-    <loc>http://cnx.org/contents/209deb1f-1a46-4369-9e0d-18674cf58a3e@7/preface-to-college-physics</loc>
-    <lastmod>2013-07-31</lastmod>
-  </url>
-  <url>
-    <loc>http://cnx.org/contents/e79ffde3-7fb4-4af3-9ec8-df648b391597@7.1/college-physics</loc>
+    <loc>http://cnx.org/contents/e79ffde3-7fb4-4af3-9ec8-df648b391597@7.1/College-Physics</loc>
     <lastmod>2013-08-31</lastmod>
   </url>
 </urlset>

--- a/cnxarchive/views/sitemap.py
+++ b/cnxarchive/views/sitemap.py
@@ -65,7 +65,7 @@ def sitemap(request):
                     ident_hash(uuid, major_version, minor_version)
                         AS idver,
                     REGEXP_REPLACE(TRIM(REGEXP_REPLACE(LOWER(name),
-                        '[^[:alnum:]]', '', 'g')), ' +', '-', 'g'),
+                        '[^[:alnum:]|  +]', '', 'g')), ' +', '-', 'g'),
                     revised
                 FROM latest_modules
                 WHERE portal_type NOT IN ('CompositeModule', 'SubCollection')

--- a/cnxarchive/views/sitemap.py
+++ b/cnxarchive/views/sitemap.py
@@ -65,7 +65,7 @@ def sitemap(request):
                     ident_hash(uuid, major_version, minor_version)
                         AS idver,
                     REGEXP_REPLACE(TRIM(REGEXP_REPLACE(LOWER(name),
-                        '[^[:alpha:]|[:digit:]]', '', 'g')), ' +', '-', 'g'),
+                        '[^[:alnum:]]', '', 'g')), ' +', '-', 'g'),
                     revised
                 FROM latest_modules
                 WHERE portal_type NOT IN ('CompositeModule', 'SubCollection')

--- a/cnxarchive/views/sitemap.py
+++ b/cnxarchive/views/sitemap.py
@@ -74,10 +74,14 @@ def sitemap(request):
                 ORDER BY module_ident DESC""".format(match))
             res = cursor.fetchall()
             for ident_hash, page_name, revised in res:
-                #  replace spaces and punctuation
-                page_name = re.sub(NON_WORD, '-',
+                #  replace punctuation with whitespace
+                page_name = re.sub(NON_WORD, ' ',
                                    page_name.decode('utf-8'), re.UNICODE)
-
+                # remove leading and trailing whitespace
+                page_name = page_name.strip().encode('utf-8')
+                # replace spaces with dashes
+                page_name = re.sub(' +', '-',
+                                   page_name.decode('utf-8'), re.UNICODE)
                 url = request.route_url('content',
                                         ident_hash=ident_hash,
                                         ignore=u'/{}'.format(page_name))

--- a/cnxarchive/views/sitemap.py
+++ b/cnxarchive/views/sitemap.py
@@ -65,7 +65,7 @@ def sitemap(request):
                     ident_hash(uuid, major_version, minor_version)
                         AS idver,
                     REGEXP_REPLACE(TRIM(REGEXP_REPLACE(LOWER(name),
-                        '[^\w\s)]', '', 'g')), ' +', '-', 'g'),
+                        '[^[:alpha:]|[:digit:]]', '', 'g')), ' +', '-', 'g'),
                     revised
                 FROM latest_modules
                 WHERE portal_type NOT IN ('CompositeModule', 'SubCollection')

--- a/cnxarchive/views/sitemap.py
+++ b/cnxarchive/views/sitemap.py
@@ -65,7 +65,7 @@ def sitemap(request):
                     ident_hash(uuid, major_version, minor_version)
                         AS idver,
                     REGEXP_REPLACE(TRIM(REGEXP_REPLACE(LOWER(name),
-                        '[^0-9a-z]+', ' ', 'g')), ' +', '-', 'g'),
+                        '/\s/', ' ', 'g')), ' +', '-', 'g'),
                     revised
                 FROM latest_modules
                 WHERE portal_type NOT IN ('CompositeModule', 'SubCollection')

--- a/cnxarchive/views/sitemap.py
+++ b/cnxarchive/views/sitemap.py
@@ -64,8 +64,8 @@ def sitemap(request):
             cursor.execute("""SELECT
                     ident_hash(uuid, major_version, minor_version)
                         AS idver,
-                    REGEXP_REPLACE(TRIM(REGEXP_REPLACE(LOWER(name),
-                        '/\s/', ' ', 'g')), ' +', '-', 'g'),
+                    REGEXP_REPLACE(TRIM(REGEXP_REPLACE(LOWER(name), 
+                        '[^\w\s)]', '', 'g')), ' +', '-', 'g'),
                     revised
                 FROM latest_modules
                 WHERE portal_type NOT IN ('CompositeModule', 'SubCollection')

--- a/cnxarchive/views/sitemap.py
+++ b/cnxarchive/views/sitemap.py
@@ -64,7 +64,7 @@ def sitemap(request):
             cursor.execute("""SELECT
                     ident_hash(uuid, major_version, minor_version)
                         AS idver,
-                    REGEXP_REPLACE(TRIM(REGEXP_REPLACE(LOWER(name), 
+                    REGEXP_REPLACE(TRIM(REGEXP_REPLACE(LOWER(name),
                         '[^\w\s)]', '', 'g')), ' +', '-', 'g'),
                     revised
                 FROM latest_modules

--- a/cnxarchive/views/sitemap.py
+++ b/cnxarchive/views/sitemap.py
@@ -14,7 +14,7 @@ from pyramid.view import view_config
 from ..database import db_connect
 from ..sitemap import Sitemap, SitemapIndex
 
-NON_WORD = re.compile('\W', re.UNICODE)
+NON_WORD = re.compile('\W+', re.UNICODE)
 
 PAGES_TO_BLOCK = [
     'legacy.cnx.org', '/lenses', '/browse_content', '/content/', '/content$',
@@ -74,11 +74,13 @@ def sitemap(request):
                 ORDER BY module_ident DESC""".format(match))
             res = cursor.fetchall()
             for ident_hash, page_name, revised in res:
-                re.sub(NON_WORD, '-', page_name) #  replace spaces and punc
+                #  replace spaces and punctuation
+                page_name = re.sub(NON_WORD, '-',
+                                   page_name.decode('utf-8'), re.UNICODE)
 
                 url = request.route_url('content',
                                         ident_hash=ident_hash,
-                                        ignore='/{}'.format(page_name))
+                                        ignore=u'/{}'.format(page_name))
                 if notblocked(url):
                     xml.add_url(url, lastmod=revised)
 

--- a/cnxarchive/views/sitemap.py
+++ b/cnxarchive/views/sitemap.py
@@ -7,12 +7,14 @@
 # ###
 """Sitemap Views."""
 import logging
-from re import compile
+import re
 
 from pyramid.view import view_config
 
 from ..database import db_connect
 from ..sitemap import Sitemap, SitemapIndex
+
+NON_WORD = re.compile('\W', re.UNICODE)
 
 PAGES_TO_BLOCK = [
     'legacy.cnx.org', '/lenses', '/browse_content', '/content/', '/content$',
@@ -39,7 +41,7 @@ def notblocked(page):
     for blocked in PAGES_TO_BLOCK:
         if blocked[0] != '*':
             blocked = '*' + blocked
-        rx = compile(blocked.replace('*', '[^$]*'))
+        rx = re.compile(blocked.replace('*', '[^$]*'))
         if rx.match(page):
             return False
     return True
@@ -64,8 +66,7 @@ def sitemap(request):
             cursor.execute("""SELECT
                     ident_hash(uuid, major_version, minor_version)
                         AS idver,
-                    REGEXP_REPLACE(TRIM(REGEXP_REPLACE(LOWER(name),
-                        '[^[:alnum:]|  +]', '', 'g')), ' +', '-', 'g'),
+                    name,
                     revised
                 FROM latest_modules
                 WHERE portal_type NOT IN ('CompositeModule', 'SubCollection')
@@ -73,6 +74,8 @@ def sitemap(request):
                 ORDER BY module_ident DESC""".format(match))
             res = cursor.fetchall()
             for ident_hash, page_name, revised in res:
+                re.sub(NON_WORD, '-', page_name) #  replace spaces and punc
+
                 url = request.route_url('content',
                                         ident_hash=ident_hash,
                                         ignore='/{}'.format(page_name))


### PR DESCRIPTION
Most of the regx came from [here](https://stackoverflow.com/questions/4328500/how-can-i-strip-all-punctuation-from-a-string-in-javascript-using-regex/25575009#25575009).

See https://github.com/Connexions/webview/pull/1631 for the frontend aspect of this, along with its test plan.

Test plan
======
Steps
------
1. Visit a sitemap for a publisher who has published a book with unicode characters (ie.: Katalyst whose books are in a different language, https://qa.cnx.org/sitemap-katalysteducation.xml)
2. Unicode (non-ascii) characters should be present in the URLs
(ie. Expect this URL https://qa.cnx.org/contents/34972a80-efe3-4f36-90d4-e0661d202e24@2/Płyny-gęstość-i-ciśnienie to be present instead of https://qa.cnx.org/contents/34972a80-efe3-4f36-90d4-e0661d202e24@2/p-yny-g-sto-i-ci-nienie

Expected result
----------------
- Unicode characters do not become stripped out from URLs in a sitemap.
- Whitespace is replaced with dashes.
- Punctuation is stripped out (ie. question marks, exclamation marks)