### PR TITLE
add info about latest version and head version to extras for content

### DIFF
--- a/cnxarchive/database.py
+++ b/cnxarchive/database.py
@@ -55,6 +55,7 @@ SQL = {
     'get-resourceid-by-filename': _read_sql_file('get-resourceid-by-filename'),
     'get-tree-by-uuid-n-version': _read_sql_file('get-tree-by-uuid-n-version'),
     'get-module-latest-version': _read_sql_file('get-module-latest-version'),
+    'get-module-head-version': _read_sql_file('get-module-head-version'),
     'get-module-versions': _read_sql_file('get-module-versions'),
     'get-module-uuid': _read_sql_file('get-module-uuid'),
     'get-subject-list': _read_sql_file('get-subject-list'),

--- a/cnxarchive/tests/views/test_content.py
+++ b/cnxarchive/tests/views/test_content.py
@@ -894,6 +894,8 @@ INSERT INTO trees (nodeid, parent_id, title, childorder, is_collated)
                 u'size': 0,
                 u'state': u'missing'}],
             u'isLatest': False,
+            u'latestVersion': u'7.1',
+            u'headVersion': u'7.1',
             u'canPublish': [
                 u'OpenStaxCollege',
                 u'cnxcap',
@@ -1007,10 +1009,10 @@ INSERT INTO trees (nodeid, parent_id, title, childorder, is_collated)
 
     def test_extra_latest(self):
         id = 'e79ffde3-7fb4-4af3-9ec8-df648b391597'
-        version = '7.1'
+        latest_version = '7.1'
 
         # Build the request
-        self.request.matchdict = {'ident_hash': '{}@{}'.format(id, version)}
+        self.request.matchdict = {'ident_hash': '{}@{}'.format(id, latest_version)}
         self.request.matched_route = mock.Mock()
         self.request.matched_route.name = 'content-extras'
 
@@ -1021,6 +1023,8 @@ INSERT INTO trees (nodeid, parent_id, title, childorder, is_collated)
         self.assertEqual(self.request.response.content_type,
                          'application/json')
         self.assertEqual(output['isLatest'], True)
+        self.assertEqual(output['latestVersion'], latest_version)
+        self.assertEqual(output['headVersion'], latest_version)
 
         version = '6.1'
 
@@ -1034,6 +1038,8 @@ INSERT INTO trees (nodeid, parent_id, title, childorder, is_collated)
         self.assertEqual(self.request.response.content_type,
                          'application/json')
         self.assertEqual(output['isLatest'], False)
+        self.assertEqual(output['latestVersion'], latest_version)
+        self.assertEqual(output['headVersion'], latest_version)
 
     def test_extra_wo_version(self):
         # Request the extras for a document, but without specifying
@@ -1145,6 +1151,8 @@ INSERT INTO trees (nodeid, parent_id, title, childorder, is_collated)
                 u'cnxcap',
                 ],
             u'isLatest': True,
+            u'latestVersion': u'5',
+            u'headVersion': u'5',
             u'downloads': [{
                 u'created': u'2015-03-04T10:03:29-08:00',
                 u'path': quote('/exports/{}@{}.pdf/useful-inførmation-5.pdf'

--- a/cnxarchive/views/content.py
+++ b/cnxarchive/views/content.py
@@ -26,7 +26,9 @@ from ..utils import (
     join_ident_hash, split_ident_hash,
     json_serial,
     )
-from .helpers import get_uuid, get_latest_version, get_content_metadata
+from .helpers import (
+    get_uuid, get_latest_version, get_head_version, get_content_metadata
+    )
 from .exports import get_export_file, ExportError
 
 HTML_WRAPPER = """\
@@ -293,6 +295,8 @@ def get_extra(request):
                 list(get_export_allowable_types(cursor, exports_dirs,
                                                 id, version))
             results['isLatest'] = is_latest(id, version)
+            results['latestVersion'] = get_latest_version(id)
+            results['headVersion'] = get_head_version(id)
             results['canPublish'] = get_module_can_publish(cursor, id)
             results['state'] = get_state(cursor, id, version)
             results['books'] = get_books_containing_page(id, version)

--- a/cnxarchive/views/helpers.py
+++ b/cnxarchive/views/helpers.py
@@ -45,6 +45,15 @@ def get_latest_version(uuid_):
             except (TypeError, IndexError,):  # None returned
                 raise httpexceptions.HTTPNotFound()
 
+def get_head_version(uuid_):
+    with db_connect() as db_connection:
+        with db_connection.cursor() as cursor:
+            cursor.execute(SQL['get-module-head-version'], {'id': uuid_})
+            try:
+                return cursor.fetchone()[0]
+            except (TypeError, IndexError,):  # None returned
+                raise httpexceptions.HTTPNotFound()
+
 
 def get_content_metadata(id, version, cursor):
     """Return metadata related to the content from the database."""


### PR DESCRIPTION
Add info to the `content-extras` route about the latest version and head version for this content. These differ in that `head` is the highest version successfully published, while `latest` now means highest version published _and baked_ for presentation.