### PR TITLE
add safe_stat util, and use it to test exports dirs before access

### DIFF
--- a/cnxarchive/tests/test_utils.py
+++ b/cnxarchive/tests/test_utils.py
@@ -5,9 +5,9 @@
 # Public License version 3 (AGPLv3).
 # See LICENCE.txt for details.
 # ###
-import os
 import uuid
 import unittest
+
 
 from ..utils import (CNXHash, IdentHashSyntaxError, IdentHashShortId,
                      IdentHashMissingVersion)
@@ -439,3 +439,16 @@ class TestCNXHash(unittest.TestCase):
             self.cnxhash.get_shortid(), self.cnxhash.get_shortid()))
         self.assertFalse(identifiers_equal(self.cnxhash, []))
         self.assertFalse(identifiers_equal(uuid.uuid4(), uuid.uuid4()))
+
+
+class SafeStatTestCase(unittest.TestCase):
+
+    def call_target(self, *args, **kwargs):
+        from ..utils import safe_stat
+        return safe_stat(*args, **kwargs)
+
+    def test_success(self):
+        self.assertTrue(self.call_target('/tmp', 1))
+
+    def test_timeout(self):
+        self.assertFalse(self.call_target('/tmp', 1, cmd=['/bin/sleep', '10']))

--- a/cnxarchive/utils/__init__.py
+++ b/cnxarchive/utils/__init__.py
@@ -12,3 +12,4 @@ from .ident_hash import *  # noqa
 from .mimetype import *  # noqa
 from .text import *  # noqa
 from .json import *  # noqa
+from .safe import safe_stat  # noqa

--- a/cnxarchive/utils/safe.py
+++ b/cnxarchive/utils/safe.py
@@ -6,24 +6,23 @@ from logging import getLogger
 
 logger = getLogger('safestat')
 
-process = None
+safe_stat_process = None
 
 
 def safe_stat(path, timeout=1, cmd=None):
     "Use threads and a subproc to bodge a timeout on top of filesystem access"
-    global process
+    global safe_stat_process
 
     if cmd is None:
         cmd = ['/usr/bin/stat']
 
     cmd.append(path)
 
-    # import pdb; pdb.set_trace()
     def target():
-        global process
+        global safe_stat_process
         logger.debug('Stat thread started')
-        process = subprocess.Popen(cmd, stdout=PIPE, stderr=PIPE)
-        _results = process.communicate()  # noqa
+        safe_stat_process = subprocess.Popen(cmd, stdout=PIPE, stderr=PIPE)
+        _results = safe_stat_process.communicate()  # noqa
         logger.debug('Stat thread finished')
 
     thread = threading.Thread(target=target)
@@ -32,6 +31,6 @@ def safe_stat(path, timeout=1, cmd=None):
     thread.join(timeout)
 
     if thread.is_alive():  # stat took longer than timeout
-        process.terminate()
+        safe_stat_process.terminate()
         thread.join()
-    return process.returncode == 0
+    return safe_stat_process.returncode == 0

--- a/cnxarchive/utils/safe.py
+++ b/cnxarchive/utils/safe.py
@@ -1,0 +1,37 @@
+import subprocess
+import threading
+
+from subprocess import PIPE
+from logging import getLogger
+
+logger = getLogger('safestat')
+
+process = None
+
+
+def safe_stat(path, timeout=1, cmd=None):
+    "Use threads and a subproc to bodge a timeout on top of filesystem access"
+    global process
+
+    if cmd is None:
+        cmd = ['/usr/bin/stat']
+
+    cmd.append(path)
+
+    # import pdb; pdb.set_trace()
+    def target():
+        global process
+        logger.debug('Stat thread started')
+        process = subprocess.Popen(cmd, stdout=PIPE, stderr=PIPE)
+        _results = process.communicate()  # noqa
+        logger.debug('Stat thread finished')
+
+    thread = threading.Thread(target=target)
+    thread.start()
+
+    thread.join(timeout)
+
+    if thread.is_alive():  # stat took longer than timeout
+        process.terminate()
+        thread.join()
+    return process.returncode == 0

--- a/cnxarchive/views/exports.py
+++ b/cnxarchive/views/exports.py
@@ -16,7 +16,7 @@ from pyramid.view import view_config
 from .. import config
 from ..database import db_connect
 from ..utils import (
-    slugify, fromtimestamp, split_ident_hash,
+    slugify, fromtimestamp, split_ident_hash, safe_stat,
     )
 from .helpers import get_content_metadata
 
@@ -95,25 +95,27 @@ def get_export_file(cursor, id, version, type, exports_dirs):
                                                 version, file_extension)
 
     for dir in exports_dirs:
-        filepath = os.path.join(dir, filename)
-        try:
-            with open(filepath, 'r') as file:
-                stats = os.fstat(file.fileno())
-                modtime = fromtimestamp(int(stats.st_mtime))
-                return (slugify_title_filename, mimetype,
-                        stats.st_size, modtime, 'good', file.read())
-        except IOError:
-            # Let's see if the legacy file's there and make the new link if so
-            legacy_filepaths = [os.path.join(dir, fn)
-                                for fn in legacy_filenames]
-            for legacy_filepath in legacy_filepaths:
-                if os.path.exists(legacy_filepath):
-                    with open(legacy_filepath, 'r') as file:
-                        stats = os.fstat(file.fileno())
-                        modtime = fromtimestamp(stats.st_mtime)
-                        os.link(legacy_filepath, filepath)
-                        return (slugify_title_filename, mimetype,
-                                stats.st_size, modtime, 'good', file.read())
+        if safe_stat(dir):
+            filepath = os.path.join(dir, filename)
+            try:
+                with open(filepath, 'r') as file:
+                    stats = os.fstat(file.fileno())
+                    modtime = fromtimestamp(int(stats.st_mtime))
+                    return (slugify_title_filename, mimetype,
+                            stats.st_size, modtime, 'good', file.read())
+            except IOError:
+                # Let's see if the legacy file's there and make the new link
+                legacy_filepaths = [os.path.join(dir, fn)
+                                    for fn in legacy_filenames]
+                for legacy_filepath in legacy_filepaths:
+                    if os.path.exists(legacy_filepath):
+                        with open(legacy_filepath, 'r') as file:
+                            stats = os.fstat(file.fileno())
+                            modtime = fromtimestamp(stats.st_mtime)
+                            os.link(legacy_filepath, filepath)
+                            return (slugify_title_filename, mimetype,
+                                    stats.st_size, modtime, 'good',
+                                    file.read())
     else:
         filenames = [filename] + legacy_filenames
         log_formatted_filenames = '\n'.join([' - {}'.format(x)


### PR DESCRIPTION
This works around the stall that happens when file IO attempts to use a stale NFS mount. The metadata about exports that is collected here is non-critical to content serving, this allows the process to report `missing` rather than freezing