### PR TITLE
extend content-disposition header w/ encoded filename

### DIFF
--- a/cnxarchive/tests/views/test_exports.py
+++ b/cnxarchive/tests/views/test_exports.py
@@ -314,9 +314,9 @@ class ExportsViewsTestCase(unittest.TestCase):
         export = get_export(self.request).body
 
         self.assertEqual(self.request.response.content_disposition,
-                         "attached; filename=college-physics-7.1.pdf;"
-                         " filename*=UTF-8''college-physics-7.1.pdf"
-                         .format(version))
+                         "attached; filename=college-physics-{ver}.pdf;"
+                         " filename*=UTF-8''college-physics-{ver}.pdf"
+                         .format(ver=version))
         expected_file = os.path.join(testing.DATA_DIRECTORY, 'exports',
                                      filename)
         with open(expected_file, 'r') as file:
@@ -334,9 +334,9 @@ class ExportsViewsTestCase(unittest.TestCase):
         export = get_export(self.request).body
         self.assertEqual(
             self.request.response.content_disposition,
-            "attached; filename=useful-inf%C3%B8rmation-5.pdf;"
-            " filename*=UTF-8''useful-inf%C3%B8rmation-5.pdf"
-            .format(version))
+            "attached; filename=useful-inf%C3%B8rmation-{ver}.pdf;"
+            " filename*=UTF-8''useful-inf%C3%B8rmation-{ver}.pdf"
+            .format(ver=version))
 
         self.assertEqual(export, '')
 
@@ -352,9 +352,9 @@ class ExportsViewsTestCase(unittest.TestCase):
         export = get_export(self.request).body
         self.assertEqual(
             self.request.response.content_disposition,
-            "attached; filename=elasticity-stress-and-strain-8.pdf;"
-            " filename*=UTF-8''elasticity-stress-and-strain-8.pdf"
-            .format(version))
+            "attached; filename=elasticity-stress-and-strain-{ver}.pdf;"
+            " filename*=UTF-8''elasticity-stress-and-strain-{ver}.pdf"
+            .format(ver=version))
 
         expected_file = os.path.join(testing.DATA_DIRECTORY, 'exports2',
                                      filename)

--- a/cnxarchive/tests/views/test_exports.py
+++ b/cnxarchive/tests/views/test_exports.py
@@ -314,12 +314,31 @@ class ExportsViewsTestCase(unittest.TestCase):
         export = get_export(self.request).body
 
         self.assertEqual(self.request.response.content_disposition,
-                         "attached; filename=college-physics-{}.pdf"
+                         "attached; filename=college-physics-7.1.pdf;"
+                         " filename*=UTF-8''college-physics-7.1.pdf"
                          .format(version))
         expected_file = os.path.join(testing.DATA_DIRECTORY, 'exports',
                                      filename)
         with open(expected_file, 'r') as file:
             self.assertEqual(export, file.read())
+
+        # Test unicode filename
+        id = 'c0a76659-c311-405f-9a99-15c71af39325'
+        version = '5'
+        ident_hash = '{}@{}'.format(id, version)
+        filename = '{}@{}.pdf'.format(id, version)
+        self.request.matchdict = {'ident_hash': ident_hash,
+                                  'type': 'pdf'
+                                  }
+
+        export = get_export(self.request).body
+        self.assertEqual(
+            self.request.response.content_disposition,
+            "attached; filename=useful-inf%C3%B8rmation-5.pdf;"
+            " filename*=UTF-8''useful-inf%C3%B8rmation-5.pdf"
+            .format(version))
+
+        self.assertEqual(export, '')
 
         # Test exports can access the other exports directory
         id = '56f1c5c1-4014-450d-a477-2121e276beca'
@@ -333,7 +352,8 @@ class ExportsViewsTestCase(unittest.TestCase):
         export = get_export(self.request).body
         self.assertEqual(
             self.request.response.content_disposition,
-            "attached; filename=elasticity-stress-and-strain-{}.pdf"
+            "attached; filename=elasticity-stress-and-strain-8.pdf;"
+            " filename*=UTF-8''elasticity-stress-and-strain-8.pdf"
             .format(version))
 
         expected_file = os.path.join(testing.DATA_DIRECTORY, 'exports2',

--- a/cnxarchive/views/exports.py
+++ b/cnxarchive/views/exports.py
@@ -8,6 +8,7 @@
 """Export Views."""
 import os
 import logging
+import urllib
 
 from pyramid import httpexceptions
 from pyramid.threadlocal import get_current_registry, get_current_request
@@ -65,10 +66,15 @@ def get_export(request):
     if state == 'missing':
         raise httpexceptions.HTTPNotFound()
 
+    encoded_filename = urllib.quote(filename.encode('utf-8'))
     resp = request.response
     resp.status = "200 OK"
     resp.content_type = mimetype
-    resp.content_disposition = u'attached; filename={}'.format(filename)
+    #  Need both filename and filename* below for various browsers
+    #  See: https://fastmail.blog/2011/06/24/download-non-english-filenames/
+    resp.content_disposition = "attached; filename={fname};" \
+                               " filename*=UTF-8''{fname}".format(
+                                       fname=encoded_filename)
     resp.body = file_content
     return resp
 


### PR DESCRIPTION
This will now not error on non-latin-1 titles.