### PR TITLE
Allow contextual urls in the page extras

### DIFF
--- a/cnxarchive/__init__.py
+++ b/cnxarchive/__init__.py
@@ -64,7 +64,7 @@ def declare_api_routes(config):
     add_route('resource', '/resources/{hash}{ignore:(/.*)?}')  # noqa cnxarchive.views:get_resource
     add_route('export', '/exports/{ident_hash}.{type}{ignore:(/.*)?}')  # noqa cnxarchive.views:get_export
     add_route('extras', '/extras{key:(/(featured|messages|licenses|subjects|languages))?}')  # noqa cnxarchive.views:extras
-    add_route('content-extras', '/extras/{ident_hash}')  # noqa cnxarchive.views:get_extra
+    add_route('content-extras', '/extras/{ident_hash:([^:/@.]+(@[0-9.]*[0-9]+)?)}{separator:(:?)}{page_ident_hash:([^:/@.]+(@[0-9.]*[0-9]+)?)?}')  # noqa cnxarchive.views:get_extra
     add_route('search', '/search')  # cnxarchive.views:search
     add_route('in-book-search', '/search/{ident_hash:([^:/]+)}')  # noqa cnxarchive.views:in-book-search
     add_route('in-book-search-page', '/search/{ident_hash:([^:/]+)}:{page_ident_hash}')  # noqa cnxarchive.views:in_book_search_highlighted_results

--- a/cnxarchive/tests/test_routes.py
+++ b/cnxarchive/tests/test_routes.py
@@ -181,8 +181,17 @@ class RoutingTestCase(unittest.TestCase):
                     }),
                 ),
             'content-extras': (
-                ('/extras/abcd-1234', {
-                    'ident_hash': 'abcd-1234',
+                ('/extras/abcd@1234', {
+                    'ident_hash': 'abcd@1234',
+                    'page_ident_hash': '',
+                    'separator': ''
+                    }),
+                ),
+            'content-extras': (
+                ('/extras/abcd@1234:efgh@5678', {
+                    'ident_hash': 'abcd@1234',
+                    'page_ident_hash': 'efgh@5678',
+                    'separator': ':'
                     }),
                 ),
             'search': (

--- a/cnxarchive/tests/views/test_content.py
+++ b/cnxarchive/tests/views/test_content.py
@@ -1124,9 +1124,9 @@ INSERT INTO trees (nodeid, parent_id, title, childorder, is_collated)
         self.assertEqual(self.request.response.status, '200 OK')
         self.assertEqual(self.request.response.content_type,
                          'application/json')
-        self.assertEqual(set(output.keys()),
-            set(['canPublish', 'downloads', 'headVersion',
-                 'isLatest', 'latestVersion', 'state']))
+        self.assertEqual(
+            set(output.keys()), set(['canPublish', 'downloads', 'headVersion',
+                                     'isLatest', 'latestVersion', 'state']))
 
     def test_extra_w_utf8_characters(self):
         id = 'c0a76659-c311-405f-9a99-15c71af39325'

--- a/cnxarchive/tests/views/test_content.py
+++ b/cnxarchive/tests/views/test_content.py
@@ -842,7 +842,9 @@ INSERT INTO trees (nodeid, parent_id, title, childorder, is_collated)
         version = '66.1'
 
         # Build the request
-        self.request.matchdict = {'ident_hash': '{}@{}'.format(id, version)}
+        self.request.matchdict = {'ident_hash': '{}@{}'.format(id, version),
+                                  'page_ident_hash': '',
+                                  'separator': ''}
         self.request.matched_route = mock.Mock()
         self.request.matched_route.name = 'content-extras'
 
@@ -856,7 +858,9 @@ INSERT INTO trees (nodeid, parent_id, title, childorder, is_collated)
         version = '6.1'
 
         # Build the request
-        self.request.matchdict = {'ident_hash': '{}@{}'.format(id, version)}
+        self.request.matchdict = {'ident_hash': '{}@{}'.format(id, version),
+                                  'page_ident_hash': '',
+                                  'separator': ''}
         self.request.matched_route = mock.Mock()
         self.request.matched_route.name = 'content-extras'
 
@@ -908,7 +912,9 @@ INSERT INTO trees (nodeid, parent_id, title, childorder, is_collated)
         version = '7.1'
 
         # Build the request
-        self.request.matchdict = {'ident_hash': '{}@{}'.format(id, version)}
+        self.request.matchdict = {'ident_hash': '{}@{}'.format(id, version),
+                                  'page_ident_hash': '',
+                                  'separator': ''}
         self.request.matched_route = mock.Mock()
         self.request.matched_route.name = 'content-extras'
 
@@ -967,7 +973,9 @@ INSERT INTO trees (nodeid, parent_id, title, childorder, is_collated)
         self.addCleanup(remove_generated_files)
 
         # Build the request
-        self.request.matchdict = {'ident_hash': requested_ident_hash}
+        self.request.matchdict = {'ident_hash': requested_ident_hash,
+                                  'page_ident_hash': '',
+                                  'separator': ''}
         self.request.matched_route = mock.Mock()
         self.request.matched_route.name = 'content-extras'
 
@@ -1012,7 +1020,9 @@ INSERT INTO trees (nodeid, parent_id, title, childorder, is_collated)
         latest_version = '7.1'
 
         # Build the request
-        self.request.matchdict = {'ident_hash': '{}@{}'.format(id, latest_version)}
+        self.request.matchdict = {'ident_hash': '{}@{}'.format(id, latest_version),
+                                  'page_ident_hash': '',
+                                  'separator': ''}
         self.request.matched_route = mock.Mock()
         self.request.matched_route.name = 'content-extras'
 
@@ -1029,7 +1039,9 @@ INSERT INTO trees (nodeid, parent_id, title, childorder, is_collated)
         version = '6.1'
 
         # Build the request
-        self.request.matchdict = {'ident_hash': '{}@{}'.format(id, version)}
+        self.request.matchdict = {'ident_hash': '{}@{}'.format(id, version),
+                                  'page_ident_hash': '',
+                                  'separator': ''}
 
         from ...views.content import get_extra
         output = get_extra(self.request).json_body
@@ -1051,7 +1063,9 @@ INSERT INTO trees (nodeid, parent_id, title, childorder, is_collated)
         expected_ident_hash = "{}@{}".format(id, version)
 
         # Build the request
-        self.request.matchdict = {'ident_hash': requested_ident_hash}
+        self.request.matchdict = {'ident_hash': requested_ident_hash,
+                                  'page_ident_hash': '',
+                                  'separator': ''}
         self.request.matched_route = mock.Mock()
         self.request.matched_route.name = 'content-extras'
 
@@ -1074,7 +1088,9 @@ INSERT INTO trees (nodeid, parent_id, title, childorder, is_collated)
 
         # Build the request
         self.request.matchdict = {
-            'ident_hash': "{}@{}".format(short_id, version)}
+            'ident_hash': "{}@{}".format(short_id, version),
+            'page_ident_hash': '',
+            'separator': ''}
         self.request.matched_route = mock.Mock()
         self.request.matched_route.name = 'content-extras'
 
@@ -1096,7 +1112,9 @@ INSERT INTO trees (nodeid, parent_id, title, childorder, is_collated)
         expected_ident_hash = "{}@{}".format(id, version)
 
         # Build the request
-        self.request.matchdict = {'ident_hash': short_id}
+        self.request.matchdict = {'ident_hash': short_id,
+                                  'page_ident_hash': '',
+                                  'separator': ''}
         self.request.matched_route = mock.Mock()
         self.request.matched_route.name = 'content-extras'
 
@@ -1114,7 +1132,8 @@ INSERT INTO trees (nodeid, parent_id, title, childorder, is_collated)
         # Build the request
         self.request.matchdict = {
             'ident_hash': '{}@{}'.format(book_id, book_version),
-            'page_ident_hash': '{}@{}'.format(page_id, page_version)}
+            'page_ident_hash': '{}@{}'.format(page_id, page_version),
+            'separator': ':'}
         self.request.matched_route = mock.Mock()
         self.request.matched_route.name = 'content-extras'
 
@@ -1134,7 +1153,9 @@ INSERT INTO trees (nodeid, parent_id, title, childorder, is_collated)
         ident_hash = '{}@{}'.format(id, version)
 
         # Build the request
-        self.request.matchdict = {'ident_hash': ident_hash}
+        self.request.matchdict = {'ident_hash': ident_hash,
+                                  'page_ident_hash': '',
+                                  'separator': ''}
         self.request.matched_route = mock.Mock()
         self.request.matched_route.name = 'content-extras'
 
@@ -1210,7 +1231,9 @@ INSERT INTO trees (nodeid, parent_id, title, childorder, is_collated)
         version = '7.1'
 
         # Build the request
-        self.request.matchdict = {'ident_hash': '{}@{}'.format(id, version)}
+        self.request.matchdict = {'ident_hash': '{}@{}'.format(id, version),
+                                  'page_ident_hash': '',
+                                  'separator': ''}
         self.request.matched_route = mock.Mock()
         self.request.matched_route.name = 'content-extras'
 
@@ -1228,7 +1251,9 @@ INSERT INTO trees (nodeid, parent_id, title, childorder, is_collated)
         version = '1.1'
 
         # Build the request
-        self.request.matchdict = {'ident_hash': '{}@{}'.format(id, version)}
+        self.request.matchdict = {'ident_hash': '{}@{}'.format(id, version),
+                                  'page_ident_hash': '',
+                                  'separator': ''}
         self.request.matched_route = mock.Mock()
         self.request.matched_route.name = 'content-extras'
 
@@ -1241,7 +1266,9 @@ INSERT INTO trees (nodeid, parent_id, title, childorder, is_collated)
         version = '1.1'
 
         # Build the request
-        self.request.matchdict = {'ident_hash': '{}@{}'.format(id, version)}
+        self.request.matchdict = {'ident_hash': '{}@{}'.format(id, version),
+                                  'page_ident_hash': '',
+                                  'separator': ''}
 
         self.assertRaises(httpexceptions.HTTPNotFound, get_extra,
                           self.request)

--- a/cnxarchive/tests/views/test_content.py
+++ b/cnxarchive/tests/views/test_content.py
@@ -1105,6 +1105,29 @@ INSERT INTO trees (nodeid, parent_id, title, childorder, is_collated)
         with self.assertRaises(IdentHashShortId) as raiser:
             get_extra(self.request)
 
+    def test_get_extra_contextual_url(self):
+        book_id = 'e79ffde3-7fb4-4af3-9ec8-df648b391597'
+        book_version = '7.1'
+        page_id = '209deb1f-1a46-4369-9e0d-18674cf58a3e'
+        page_version = '7'
+
+        # Build the request
+        self.request.matchdict = {
+            'ident_hash': '{}@{}'.format(book_id, book_version),
+            'page_ident_hash': '{}@{}'.format(page_id, page_version)}
+        self.request.matched_route = mock.Mock()
+        self.request.matched_route.name = 'content-extras'
+
+        from ...views.content import get_extra
+        output = get_extra(self.request).json_body
+
+        self.assertEqual(self.request.response.status, '200 OK')
+        self.assertEqual(self.request.response.content_type,
+                         'application/json')
+        self.assertEqual(set(output.keys()),
+            set(['canPublish', 'downloads', 'headVersion',
+                 'isLatest', 'latestVersion', 'state']))
+
     def test_extra_w_utf8_characters(self):
         id = 'c0a76659-c311-405f-9a99-15c71af39325'
         version = '5'


### PR DESCRIPTION
Should cut the time to load extras for physics pages by about half once webview uses this new route (not as much for other books since physics is probably the worst case for this issue).