### PR TITLE
Faster book extras and more accurate contextual page extras

### DIFF
--- a/cnxarchive/tests/views/test_content.py
+++ b/cnxarchive/tests/views/test_content.py
@@ -1123,7 +1123,29 @@ INSERT INTO trees (nodeid, parent_id, title, childorder, is_collated)
         with self.assertRaises(IdentHashShortId) as raiser:
             get_extra(self.request)
 
-    def test_get_extra_contextual_url(self):
+    def test_get_extra_book(self):
+        book_id = 'e79ffde3-7fb4-4af3-9ec8-df648b391597'
+        book_version = '7.1'
+
+        # Build the request
+        self.request.matchdict = {
+            'ident_hash': '{}@{}'.format(book_id, book_version),
+            'page_ident_hash': '',
+            'separator': ':'}
+        self.request.matched_route = mock.Mock()
+        self.request.matched_route.name = 'content-extras'
+
+        from ...views.content import get_extra
+        output = get_extra(self.request).json_body
+
+        self.assertEqual(self.request.response.status, '200 OK')
+        self.assertEqual(self.request.response.content_type,
+                         'application/json')
+        self.assertEqual(set(output.keys()), set([
+            'canPublish', 'downloads', 'headVersion',
+            'isLatest', 'latestVersion', 'state']))
+
+    def test_get_extra_page_contextual_url(self):
         book_id = 'e79ffde3-7fb4-4af3-9ec8-df648b391597'
         book_version = '7.1'
         page_id = '209deb1f-1a46-4369-9e0d-18674cf58a3e'
@@ -1143,9 +1165,31 @@ INSERT INTO trees (nodeid, parent_id, title, childorder, is_collated)
         self.assertEqual(self.request.response.status, '200 OK')
         self.assertEqual(self.request.response.content_type,
                          'application/json')
-        self.assertEqual(
-            set(output.keys()), set(['canPublish', 'downloads', 'headVersion',
-                                     'isLatest', 'latestVersion', 'state']))
+        self.assertEqual(set(output.keys()), set([
+            'canPublish', 'downloads', 'headVersion',
+            'isLatest', 'latestVersion', 'state']))
+
+    def test_get_extra_page_non_contextual_url(self):
+        page_id = '209deb1f-1a46-4369-9e0d-18674cf58a3e'
+        page_version = '7'
+
+        # Build the request
+        self.request.matchdict = {
+            'ident_hash': '{}@{}'.format(page_id, page_version),
+            'page_ident_hash': '',
+            'separator': ':'}
+        self.request.matched_route = mock.Mock()
+        self.request.matched_route.name = 'content-extras'
+
+        from ...views.content import get_extra
+        output = get_extra(self.request).json_body
+
+        self.assertEqual(self.request.response.status, '200 OK')
+        self.assertEqual(self.request.response.content_type,
+                         'application/json')
+        self.assertEqual(set(output.keys()), set([
+            'books', 'canPublish', 'downloads', 'headVersion',
+            'isLatest', 'latestVersion', 'state']))
 
     def test_extra_w_utf8_characters(self):
         id = 'c0a76659-c311-405f-9a99-15c71af39325'

--- a/cnxarchive/tests/views/test_content.py
+++ b/cnxarchive/tests/views/test_content.py
@@ -1142,8 +1142,9 @@ INSERT INTO trees (nodeid, parent_id, title, childorder, is_collated)
         self.assertEqual(self.request.response.content_type,
                          'application/json')
         self.assertEqual(set(output.keys()), set([
-            'canPublish', 'downloads', 'headVersion',
+            'books', 'canPublish', 'downloads', 'headVersion',
             'isLatest', 'latestVersion', 'state']))
+        self.assertEqual(output['books'], [])
 
     def test_get_extra_page_contextual_url(self):
         book_id = 'e79ffde3-7fb4-4af3-9ec8-df648b391597'
@@ -1166,8 +1167,19 @@ INSERT INTO trees (nodeid, parent_id, title, childorder, is_collated)
         self.assertEqual(self.request.response.content_type,
                          'application/json')
         self.assertEqual(set(output.keys()), set([
-            'canPublish', 'downloads', 'headVersion',
+            'books', 'canPublish', 'downloads', 'headVersion',
             'isLatest', 'latestVersion', 'state']))
+        self.assertEqual(output['books'], [
+            {u'authors': [{u'username': u'OpenStaxCollege',
+                           u'fullname': u'OpenStax College',
+                           u'suffix': None,
+                           u'title': None,
+                           u'surname': None,
+                           u'firstname': u'OpenStax College'}],
+             u'title': u'College Physics',
+             u'ident_hash': u'e79ffde3-7fb4-4af3-9ec8-df648b391597@7.1',
+             u'revised': u'2013-08-31T12:07:20.342798-07:00',
+             u'shortid': u'55_943-0@7.1'}])
 
     def test_get_extra_page_non_contextual_url(self):
         page_id = '209deb1f-1a46-4369-9e0d-18674cf58a3e'
@@ -1190,6 +1202,28 @@ INSERT INTO trees (nodeid, parent_id, title, childorder, is_collated)
         self.assertEqual(set(output.keys()), set([
             'books', 'canPublish', 'downloads', 'headVersion',
             'isLatest', 'latestVersion', 'state']))
+        output['books'].sort()
+        self.assertEqual(output['books'], [
+            {u'authors': [{u'username': u'OpenStaxCollege',
+                           u'fullname': u'OpenStax College',
+                           u'suffix': None,
+                           u'title': None,
+                           u'surname': None,
+                           u'firstname': u'OpenStax College'}],
+             u'title': u'<span style="color:red;">Derived</span> Copy of College <i>Physics</i>',
+             u'ident_hash': u'a733d0d2-de9b-43f9-8aa9-f0895036899e@1.1',
+             u'revised': u'2013-08-31T12:07:20.342798-07:00',
+             u'shortid': u'pzPQ0t6b@1.1'},
+            {u'authors': [{u'username': u'OpenStaxCollege',
+                           u'fullname': u'OpenStax College',
+                           u'suffix': None,
+                           u'title': None,
+                           u'surname': None,
+                           u'firstname': u'OpenStax College'}],
+             u'title': u'College Physics',
+             u'ident_hash': u'e79ffde3-7fb4-4af3-9ec8-df648b391597@7.1',
+             u'revised': u'2013-08-31T12:07:20.342798-07:00',
+             u'shortid': u'55_943-0@7.1'}])
 
     def test_extra_w_utf8_characters(self):
         id = 'c0a76659-c311-405f-9a99-15c71af39325'
@@ -1210,18 +1244,9 @@ INSERT INTO trees (nodeid, parent_id, title, childorder, is_collated)
         self.assertEqual(self.request.response.content_type,
                          'application/json')
         output['canPublish'].sort()
+        output['books'].sort()
         self.assertEqual(output, {
             u'books': [
-                {u'authors': [{u'username': u'OpenStaxCollege',
-                               u'fullname': u'OpenStax College',
-                               u'suffix': None,
-                               u'title': None,
-                               u'surname': None,
-                               u'firstname': u'OpenStax College'}],
-                 u'title': u'College Physics',
-                 u'ident_hash': u'e79ffde3-7fb4-4af3-9ec8-df648b391597@7.1',
-                 u'revised': u'2013-08-31T12:07:20.342798-07:00',
-                 u'shortid': u'55_943-0@7.1'},
                 {u'authors': [{u'username': u'OpenStaxCollege',
                                u'fullname': u'OpenStax College',
                                u'suffix': None,
@@ -1232,6 +1257,16 @@ INSERT INTO trees (nodeid, parent_id, title, childorder, is_collated)
                  u'ident_hash': u'a733d0d2-de9b-43f9-8aa9-f0895036899e@1.1',
                  u'revised': u'2013-08-31T12:07:20.342798-07:00',
                  u'shortid': u'pzPQ0t6b@1.1'},
+                {u'authors': [{u'username': u'OpenStaxCollege',
+                               u'fullname': u'OpenStax College',
+                               u'suffix': None,
+                               u'title': None,
+                               u'surname': None,
+                               u'firstname': u'OpenStax College'}],
+                 u'title': u'College Physics',
+                 u'ident_hash': u'e79ffde3-7fb4-4af3-9ec8-df648b391597@7.1',
+                 u'revised': u'2013-08-31T12:07:20.342798-07:00',
+                 u'shortid': u'55_943-0@7.1'}
                 ],
             u'state': u'current',
             u'canPublish': [

--- a/cnxarchive/views/content.py
+++ b/cnxarchive/views/content.py
@@ -205,23 +205,6 @@ def get_state(cursor, id, version):
         return res[0]
 
 
-def get_portal_type(cursor, id, version):
-    """Return the module's portal_type."""
-    args = join_ident_hash(id, version)
-    sql_statement = """
-    SELECT m.portal_type
-    FROM modules as m
-    WHERE ident_hash(uuid, major_version, minor_version) = %s
-    """
-
-    cursor.execute(sql_statement, vars=(args,))
-    res = cursor.fetchone()
-    if res is None:
-        return None
-    else:
-        return res[0]
-
-
 def get_export_allowable_types(cursor, exports_dirs, id, version):
     """Return export types."""
     request = get_current_request()
@@ -246,18 +229,79 @@ def get_export_allowable_types(cursor, exports_dirs, id, version):
             pass
 
 
-def get_books_containing_page(uuid, version):
+# NOTE: Expects a RealDictCursor
+def get_module_info(cursor, id, version):
+    """Return a module's title, id, shortId authors and revised date."""
+    args = join_ident_hash(id, version)
+    sql_statement = """
+    SELECT m.name as title,
+           ident_hash(m.uuid, m.major_version, m.minor_version)
+           as ident_hash,
+           short_ident_hash(m.uuid, m.major_version, m.minor_version)
+           as shortId, ARRAY(
+               SELECT row_to_json(user_row)
+               FROM (
+                   SELECT u.username, u.first_name as firstname,
+                        u.last_name as surname, u.full_name as fullname,
+                        u.title, u.suffix
+               ) as user_row
+           ) as authors,
+           m.revised
+    FROM modules m
+    JOIN users as u on u.username = ANY(m.authors)
+    WHERE ident_hash(m.uuid, m.major_version, m.minor_version) = %s
+    """
+
+    cursor.execute(sql_statement, vars=(args,))
+    res = cursor.fetchone()
+    if res is None:
+        return None
+    else:
+        return res
+
+
+# NOTE: Expects a RealDictCursor
+def get_portal_type(cursor, id, version):
+    """Return the module's portal_type."""
+    args = join_ident_hash(id, version)
+    sql_statement = """
+    SELECT m.portal_type
+    FROM modules as m
+    WHERE ident_hash(uuid, major_version, minor_version) = %s
+    """
+
+    cursor.execute(sql_statement, vars=(args,))
+    res = cursor.fetchone()
+    if res is None:
+        return None
+    else:
+        return res['portal_type']
+
+
+def get_books_containing_page(uuid, version,
+                              context_uuid=None, context_version=None):
     """Return a list of book names and UUIDs
     that contain a given module UUID."""
-
     with db_connect() as db_connection:
+        # Uses a RealDictCursor instead of the regular cursor
         with db_connection.cursor(
                 cursor_factory=psycopg2.extras.RealDictCursor) as cursor:
-            cursor.execute(SQL['get-books-containing-page'],
-                           {'document_uuid': uuid,
-                            'document_version': version})
-            results = cursor.fetchall()
-    return results
+            # In the future the books-containing-page SQL might handle
+            # all of these cases. For now we branch the code out in here.
+            if context_uuid and context_version:
+                # NOTE: Currently does not check that
+                # the page is actually in the book
+                return [get_module_info(cursor, context_uuid, context_version)]
+            else:
+                portal_type = get_portal_type(cursor, uuid, version)
+                if portal_type == 'Module':
+                    cursor.execute(SQL['get-books-containing-page'],
+                                   {'document_uuid': uuid,
+                                    'document_version': version})
+                    return cursor.fetchall()
+                else:
+                    # Books are currently not in any other book
+                    return []
 
 # ######### #
 #   Views   #
@@ -304,8 +348,8 @@ def get_extra(request):
     settings = get_current_registry().settings
     exports_dirs = settings['exports-directories'].split()
     args = request.matchdict
-    is_contextual = bool(args['page_ident_hash'])
-    if is_contextual:
+    if args['page_ident_hash']:
+        context_id, context_version = split_ident_hash(args['ident_hash'])
         try:
             id, version = split_ident_hash(args['page_ident_hash'])
         except IdentHashShortId as e:
@@ -317,6 +361,7 @@ def get_extra(request):
             id = e.id
             version = get_latest_version(e.id)
     else:
+        context_id = context_version = None
         id, version = split_ident_hash(args['ident_hash'])
     results = {}
     with db_connect() as db_connection:
@@ -329,11 +374,10 @@ def get_extra(request):
             results['headVersion'] = get_head_version(id)
             results['canPublish'] = get_module_can_publish(cursor, id)
             results['state'] = get_state(cursor, id, version)
-
-            if not is_contextual:
-                if get_portal_type(cursor, id, version) == 'Module':
-                    results['books'] = get_books_containing_page(id, version)
-                    formatAuthors(results['books'])
+            results['books'] = get_books_containing_page(id, version,
+                                                         context_id,
+                                                         context_version)
+            formatAuthors(results['books'])
 
     resp = request.response
     resp.content_type = 'application/json'

--- a/cnxarchive/views/content.py
+++ b/cnxarchive/views/content.py
@@ -205,6 +205,23 @@ def get_state(cursor, id, version):
         return res[0]
 
 
+def get_portal_type(cursor, id, version):
+    """Return the module's portal_type."""
+    args = join_ident_hash(id, version)
+    sql_statement = """
+    SELECT m.portal_type
+    FROM modules as m
+    WHERE ident_hash(uuid, major_version, minor_version) = %s
+    """
+
+    cursor.execute(sql_statement, vars=(args,))
+    res = cursor.fetchone()
+    if res is None:
+        return None
+    else:
+        return res[0]
+
+
 def get_export_allowable_types(cursor, exports_dirs, id, version):
     """Return export types."""
     request = get_current_request()
@@ -314,8 +331,9 @@ def get_extra(request):
             results['state'] = get_state(cursor, id, version)
 
             if not is_contextual:
-                results['books'] = get_books_containing_page(id, version)
-                formatAuthors(results['books'])
+                if get_portal_type(cursor, id, version) == 'Module':
+                    results['books'] = get_books_containing_page(id, version)
+                    formatAuthors(results['books'])
 
     resp = request.response
     resp.content_type = 'application/json'


### PR DESCRIPTION
Webview loads book extras when loading books, but never displays the "list of books this book is in". We now return an empty array for that, skipping the DB query.

For contextual page extras requests, we now return the book that was requested. Still fast, but slightly more accurate. However, we still do not check that the page is actually in the requested book.