### PR TITLE
add link header to PDFs via http

### DIFF
--- a/cnxarchive/tests/views/test_exports.py
+++ b/cnxarchive/tests/views/test_exports.py
@@ -314,7 +314,7 @@ class ExportsViewsTestCase(unittest.TestCase):
         export = get_export(self.request).body
 
         self.assertEqual(self.request.response.content_disposition,
-                         "attached; filename=college-physics-{ver}.pdf;"
+                         "attachment; filename=college-physics-{ver}.pdf;"
                          " filename*=UTF-8''college-physics-{ver}.pdf"
                          .format(ver=version))
         expected_file = os.path.join(testing.DATA_DIRECTORY, 'exports',
@@ -334,7 +334,7 @@ class ExportsViewsTestCase(unittest.TestCase):
         export = get_export(self.request).body
         self.assertEqual(
             self.request.response.content_disposition,
-            "attached; filename=useful-inf%C3%B8rmation-{ver}.pdf;"
+            "attachment; filename=useful-inf%C3%B8rmation-{ver}.pdf;"
             " filename*=UTF-8''useful-inf%C3%B8rmation-{ver}.pdf"
             .format(ver=version))
 
@@ -352,7 +352,7 @@ class ExportsViewsTestCase(unittest.TestCase):
         export = get_export(self.request).body
         self.assertEqual(
             self.request.response.content_disposition,
-            "attached; filename=elasticity-stress-and-strain-{ver}.pdf;"
+            "attachment; filename=elasticity-stress-and-strain-{ver}.pdf;"
             " filename*=UTF-8''elasticity-stress-and-strain-{ver}.pdf"
             .format(ver=version))
 

--- a/cnxarchive/views/exports.py
+++ b/cnxarchive/views/exports.py
@@ -77,8 +77,9 @@ def get_export(request):
                                " filename*=UTF-8''{fname}".format(
                                        fname=encoded_filename)
     resp.body = file_content
-    resp.headerlist.append(('Link',
-        '<https://{}/contents/{}/{}> ;rel="Canonical"'.format(request.host, ident_hash, encoded_filename[:-4])))
+    resp.headerlist.append(
+            ('Link', '<https://{}/contents/{}/{}> ;rel="Canonical"'.format(
+                            request.host, ident_hash, encoded_filename[:-4])))
     return resp
 
 

--- a/cnxarchive/views/exports.py
+++ b/cnxarchive/views/exports.py
@@ -73,10 +73,12 @@ def get_export(request):
     resp.content_type = mimetype
     #  Need both filename and filename* below for various browsers
     #  See: https://fastmail.blog/2011/06/24/download-non-english-filenames/
-    resp.content_disposition = "attached; filename={fname};" \
+    resp.content_disposition = "attachment; filename={fname};" \
                                " filename*=UTF-8''{fname}".format(
                                        fname=encoded_filename)
     resp.body = file_content
+    resp.headerlist.append(('Link',
+        '<https://{}/contents/{}/{}> ;rel="Canonical"'.format(request.host, ident_hash, encoded_filename[:-4])))
     return resp
 
 


### PR DESCRIPTION
This adds a 'LINK' header to the HTTP response, when returned from an /exports/*pdf url.

