### PR TITLE
remove version from canonical link

### DIFF
--- a/cnxarchive/tests/views/test_exports.py
+++ b/cnxarchive/tests/views/test_exports.py
@@ -319,8 +319,8 @@ class ExportsViewsTestCase(unittest.TestCase):
                          .format(ver=version))
         self.assertEqual(self.request.response.headers['Link'],
                          '<https://example.com:80/contents/{id}'
-                         '/college-physics-{ver}> ;rel="Canonical"'
-                         .format(id=ident_hash, ver=version))
+                         '/college-physics> ;rel="Canonical"'
+                         .format(id=id))
 
         expected_file = os.path.join(testing.DATA_DIRECTORY, 'exports',
                                      filename)

--- a/cnxarchive/views/exports.py
+++ b/cnxarchive/views/exports.py
@@ -77,9 +77,11 @@ def get_export(request):
                                " filename*=UTF-8''{fname}".format(
                                        fname=encoded_filename)
     resp.body = file_content
+    #  Remove version and extension from filename, to recover title slug
+    slug_title = '-'.join(encoded_filename.split('-')[:-1])
     resp.headerlist.append(
             ('Link', '<https://{}/contents/{}/{}> ;rel="Canonical"'.format(
-                            request.host, ident_hash, encoded_filename[:-4])))
+                           request.host, id, slug_title)))
     return resp
 
 


### PR DESCRIPTION
The version is _not_ supposed to be part of the canonical URL (per https://docs.google.com/document/d/18cjuLutHYOY3eWuxf14lXiblfuJ8KbEdC4PN3a4yHEw)
