### PR TITLE
Cache exports for only 1 minute since they can be overwritten

### DIFF
--- a/cnxarchive/views/exports.py
+++ b/cnxarchive/views/exports.py
@@ -46,7 +46,7 @@ class ExportError(Exception):
 
 
 @view_config(route_name='export', request_method='GET',
-             http_cache=(31536000, {'public': True}))
+             http_cache=(60, {'public': True}))
 def get_export(request):
     """Retrieve an export file."""
     settings = get_current_registry().settings


### PR DESCRIPTION
When collections get a minor version rev.