### PR TITLE
Add Cache-Control headers for redirects

### DIFF
--- a/cnxarchive/views/content.py
+++ b/cnxarchive/views/content.py
@@ -104,6 +104,8 @@ def _get_content_json(ident_hash=None):
                             # 302 'cause lack of baked content may be temporary
                             raise httpexceptions.HTTPFound(request.route_path(
                                 request.matched_route.name,
+                                headers=[("Cache-Control",
+                                          "max-age=60, public")],
                                 _query=request.params,
                                 ident_hash=join_ident_hash(id, version),
                                 ext=routing_args['ext']))

--- a/cnxarchive/views/exceptions.py
+++ b/cnxarchive/views/exceptions.py
@@ -71,4 +71,5 @@ def ident_hash_missing_version(exc, request):
     route_args = request.matchdict.copy()
     route_args['ident_hash'] = join_ident_hash(exc.id, version)
     return httpexceptions.HTTPFound(request.route_path(
-        route_name, _query=request.params, **route_args))
+        route_name, _query=request.params, **route_args),
+        headers=[("Cache-Control", "max-age=60, public")])

--- a/cnxarchive/views/legacy_redirect.py
+++ b/cnxarchive/views/legacy_redirect.py
@@ -95,7 +95,9 @@ def redirect_legacy_content(request):
                     raise httpexceptions.HTTPMovedPermanently(
                          request.route_path(
                             'resource', hash=resourceid,
-                            ignore=u'/{}'.format(filename)))
+                            ignore=u'/{}'.format(filename)),
+                         headers=[("Cache-Control",
+                                   "max-age=31536000, public")])
                 except TypeError:  # None returned
                     raise httpexceptions.HTTPNotFound()
 
@@ -109,4 +111,5 @@ def redirect_legacy_content(request):
                 _get_page_in_book(id, version, book_uuid, book_version)
 
     raise httpexceptions.HTTPMovedPermanently(
-        request.route_path('content', ident_hash=ident_hash))
+        request.route_path('content', ident_hash=ident_hash),
+        headers=[("Cache-Control", "max-age=31536000, public")])


### PR DESCRIPTION
So 301's are cached forever and we don't rely on the varnish override for 302's.