### PR TITLE
Cache content extras for 10 minutes instead of 1 (might help with load)

### DIFF
--- a/cnxarchive/views/content.py
+++ b/cnxarchive/views/content.py
@@ -352,7 +352,7 @@ def get_content(request):
 
 
 @view_config(route_name='content-extras', request_method='GET',
-             http_cache=(60, {'public': True}))
+             http_cache=(600, {'public': True}))
 def get_extra(request):
     """Return information about a module / collection that cannot be cached."""
     settings = get_current_registry().settings


### PR DESCRIPTION
Collection extras occupy an archive worker for ~5 seconds and we don't have that many of them.