### PR TITLE
Fixed the redirect cache headers

### DIFF
--- a/cnxarchive/views/content.py
+++ b/cnxarchive/views/content.py
@@ -104,11 +104,11 @@ def _get_content_json(ident_hash=None):
                             # 302 'cause lack of baked content may be temporary
                             raise httpexceptions.HTTPFound(request.route_path(
                                 request.matched_route.name,
-                                headers=[("Cache-Control",
-                                          "max-age=60, public")],
                                 _query=request.params,
                                 ident_hash=join_ident_hash(id, version),
-                                ext=routing_args['ext']))
+                                ext=routing_args['ext']),
+                                headers=[("Cache-Control",
+                                          "max-age=60, public")])
                     raise httpexceptions.HTTPNotFound()
             else:
                 # Grab the html content.

--- a/cnxarchive/views/exceptions.py
+++ b/cnxarchive/views/exceptions.py
@@ -58,7 +58,8 @@ def ident_hash_short_id(exc, request):
     route_args = request.matchdict.copy()
     route_args['ident_hash'] = join_ident_hash(uuid_, exc.version)
     return httpexceptions.HTTPMovedPermanently(request.route_path(
-        route_name, _query=request.params, **route_args))
+        route_name, _query=request.params, **route_args),
+        headers=[("Cache-Control", "max-age=31536000, public")])
 
 
 @view_config(context=IdentHashMissingVersion)


### PR DESCRIPTION
# Tested:

## Short ids:

http://localhost:6543/contents/55_943-0 => Cache-Control: max-age=60, public 302 to http://localhost:6543/contents/e79ffde3-7fb4-4af3-9ec8-df648b391597@7.1

http://localhost:6543/contents/55_943-0@7.1 => Cache-Control: max-age=31536000, public 301 to http://localhost:6543/contents/e79ffde3-7fb4-4af3-9ec8-df648b391597@7.1

http://localhost:6543/contents/55_943-0:88mrcKkW => Cache-Control: max-age=60, public 302 to http://localhost:6543/contents/e79ffde3-7fb4-4af3-9ec8-df648b391597@7.1:88mrcKkW

http://localhost:6543/contents/55_943-0@7.1:88mrcKkW => Cache-Control: max-age=31536000, public 301 to http://localhost:6543/contents/e79ffde3-7fb4-4af3-9ec8-df648b391597@7.1:88mrcKkW

http://localhost:6543/contents/55_943-0@7.1:88mrcKkW@3 => Cache-Control: max-age=31536000, public 301 to http://localhost:6543/contents/e79ffde3-7fb4-4af3-9ec8-df648b391597@7.1:88mrcKkW@3

## Legacy redirects:

http://localhost:6543/content/col11406 => Cache-Control: max-age=60, public 301 to http://localhost:6543/contents/e79ffde3-7fb4-4af3-9ec8-df648b391597@7.1

http://localhost:6543/content/col11406/latest => Cache-Control: max-age=60, public 301 to http://localhost:6543/contents/e79ffde3-7fb4-4af3-9ec8-df648b391597@7.1

http://localhost:6543/content/col11406/1.7 => Cache-Control: max-age=60, public 301 to http://localhost:6543/contents/e79ffde3-7fb4-4af3-9ec8-df648b391597@7.1

http://localhost:6543/content/m42955 => Cache-Control: max-age=60, public 301 to http://localhost:6543/contents/209deb1f-1a46-4369-9e0d-18674cf58a3e@7

http://localhost:6543/content/m42955/latest => Cache-Control: max-age=60, public 301 to http://localhost:6543/contents/209deb1f-1a46-4369-9e0d-18674cf58a3e@7

http://localhost:6543/content/m42955/1.7 => Cache-Control: max-age=60, public 301 to http://localhost:6543/contents/209deb1f-1a46-4369-9e0d-18674cf58a3e@7

http://localhost:6543/content/m42955/latest/?collection=col11406 => Cache-Control: max-age=60, public 301 to http://localhost:6543/contents/e79ffde3-7fb4-4af3-9ec8-df648b391597@7.1:209deb1f-1a46-4369-9e0d-18674cf58a3e

http://localhost:6543/content/m42955/latest/?collection=col11406/1.7 => Cache-Control: max-age=60, public 301 to http://localhost:6543/contents/e79ffde3-7fb4-4af3-9ec8-df648b391597@7.1:209deb1f-1a46-4369-9e0d-18674cf58a3e

http://localhost:6543/content/m42955/1.7/?collection=col11406 => Cache-Control: max-age=60, public 301 to http://localhost:6543/contents/e79ffde3-7fb4-4af3-9ec8-df648b391597@7.1:209deb1f-1a46-4369-9e0d-18674cf58a3e

http://localhost:6543/content/m42955/1.7/?collection=col11406/1.7 => Cache-Control: max-age=60, public 301 to http://localhost:6543/contents/e79ffde3-7fb4-4af3-9ec8-df648b391597@7.1:209deb1f-1a46-4369-9e0d-18674cf58a3e

## Lack of baked content:

http://localhost:6543/contents/e79ffde3-7fb4-4af3-9ec8-df648b391597@7.1:88mrcKkW => Cache-Control: max-age=60, public 302 to http://localhost:6543/contents/f3c9ab70-a916-4d8c-9256-42953287b4e9@3

http://localhost:6543/contents/e79ffde3-7fb4-4af3-9ec8-df648b391597@7.1:88mrcKkW@3 => Cache-Control: max-age=60, public 302 to http://localhost:6543/contents/f3c9ab70-a916-4d8c-9256-42953287b4e9@3

http://localhost:6543/contents/e79ffde3-7fb4-4af3-9ec8-df648b391597@7.1:f3c9ab70-a916-4d8c-9256-42953287b4e9 => Cache-Control: max-age=60, public 302 to http://localhost:6543/contents/f3c9ab70-a916-4d8c-9256-42953287b4e9@3

http://localhost:6543/contents/e79ffde3-7fb4-4af3-9ec8-df648b391597@7.1:f3c9ab70-a916-4d8c-9256-42953287b4e9@3 => Cache-Control: max-age=60, public 302 to http://localhost:6543/contents/f3c9ab70-a916-4d8c-9256-42953287b4e9@3

http://localhost:6543/contents/e79ffde3-7fb4-4af3-9ec8-df648b391597@7.1:209deb1f-1a46-4369-9e0d-18674cf58a3e => Cache-Control: max-age=60, public 302 to http://localhost:6543/contents/209deb1f-1a46-4369-9e0d-18674cf58a3e@7