### PR TITLE
Return 404 for invalid contents slugs

### DIFF
--- a/cnxarchive/__init__.py
+++ b/cnxarchive/__init__.py
@@ -60,7 +60,7 @@ def declare_api_routes(config):
         return config.add_route(name, path, *args,
                                 pregenerator=pregenerator(path), **kwargs)
 
-    add_route('content', '/contents/{ident_hash:([^:/@.]+(@[0-9.]*[0-9]+)?)}{separator:(:?)}{page_ident_hash:([^:/@.]+(@[0-9.]*[0-9]+)?)?}{ignore:(/[^/.]*?)?}{ext:([.](html|json))?}')  # noqa cnxarchive.views:get_content
+    add_route('content', '/contents/{ident_hash:([^:/@.]+(@[0-9.]*[0-9]+)?)}{separator:(:?)}{page_ident_hash:([^:/@.]+(@[0-9.]*[0-9]+)?)?}{ignore:(/[^/.]*?/?)?}{ext:([.](html|json))?}')  # noqa cnxarchive.views:get_content
     add_route('resource', '/resources/{hash}{ignore:(/.*)?}')  # noqa cnxarchive.views:get_resource
     add_route('export', '/exports/{ident_hash}.{type}{ignore:(/.*)?}')  # noqa cnxarchive.views:get_export
     add_route('extras', '/extras{key:(/(featured|messages|licenses|subjects|languages))?}')  # noqa cnxarchive.views:extras

--- a/cnxarchive/__init__.py
+++ b/cnxarchive/__init__.py
@@ -60,7 +60,7 @@ def declare_api_routes(config):
         return config.add_route(name, path, *args,
                                 pregenerator=pregenerator(path), **kwargs)
 
-    add_route('content', '/contents/{ident_hash:([^:/@.]+(@[0-9.]*[0-9]+)?)}{separator:(:?)}{page_ident_hash:([^:/@.]+(@[0-9.]*[0-9]+)?)?}{ignore:(/.*?)?}{ext:([.](html|json))?}')  # noqa cnxarchive.views:get_content
+    add_route('content', '/contents/{ident_hash:([^:/@.]+(@[0-9.]*[0-9]+)?)}{separator:(:?)}{page_ident_hash:([^:/@.]+(@[0-9.]*[0-9]+)?)?}{ignore:(/[^/.]*?)?}{ext:([.](html|json))?}')  # noqa cnxarchive.views:get_content
     add_route('resource', '/resources/{hash}{ignore:(/.*)?}')  # noqa cnxarchive.views:get_resource
     add_route('export', '/exports/{ident_hash}.{type}{ignore:(/.*)?}')  # noqa cnxarchive.views:get_export
     add_route('extras', '/extras{key:(/(featured|messages|licenses|subjects|languages))?}')  # noqa cnxarchive.views:extras


### PR DESCRIPTION
- Return 404 for slugs in `/contents` that contain / or . (except trailing /)
- Added some tests for slugs