### PR TITLE
Deploy and run functional tests from jenkins

### DIFF
--- a/.jenkins/deploy
+++ b/.jenkins/deploy
@@ -1,5 +1,8 @@
 pipeline {
   agent { label 'docker' }
+  environment {
+    TESTING_CONTAINER_NAME = "archive-testing-${env.BUILD_ID}"
+  }
   stages {
     stage('Build') {
       steps {
@@ -11,6 +14,34 @@ pipeline {
         // 'docker-registry' is defined in Jenkins under credentials
         withDockerRegistry([credentialsId: 'docker-registry', url: '']) {
           sh "docker push openstax/cnx-archive:dev"
+        }
+      }
+    }
+    stage('Deploy to the Staging stack') {
+      steps {
+        // Requires DOCKER_HOST be set in the Jenkins Configuration.
+        // Using the environment variable enables this file to be
+        // endpoint agnostic.
+        sh "docker -H ${CNX_STAGING_DOCKER_HOST} service update --label-add 'git.commit-hash=${GIT_COMMIT}' --image openstax/cnx-archive:dev staging_archive"
+      }
+    }
+    stage('Run Functional Tests'){
+      steps {
+        sh "mkdir -p ${WORKSPACE}/xml-report"
+        sh "${WORKSPACE}/.jenkins/gen_env_list.py ${CNX_STAGING_DOCKER_HOST} > ${WORKSPACE}/env.list"
+        // Start the testing container
+        sh "docker run -d -v ${WORKSPACE}/xml-report:/xml-report:z --env-file ${WORKSPACE}/env.list --name ${TESTING_CONTAINER_NAME} openstax/cnx-automation:latest"
+        // Run the tests
+        sh "docker exec ${TESTING_CONTAINER_NAME} tox -- -m 'webview and not (requires_deployment or requires_varnish_routing or legacy)' --junitxml=/code/report.xml"
+      }
+      post {
+        always {
+          // Move the report to a place that is both accessible and writable
+          sh "docker exec -u root ${TESTING_CONTAINER_NAME} cp /code/report.xml /xml-report"
+          // Destroy the testing container
+          sh "docker stop ${TESTING_CONTAINER_NAME} && docker rm -f ${TESTING_CONTAINER_NAME}"
+          // Report test results
+          junit "xml-report/report.xml"
         }
       }
     }

--- a/.jenkins/gen_env_list.py
+++ b/.jenkins/gen_env_list.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python3
+"""\
+This is used to build an environment variable list for use with containers.
+
+"""
+import argparse
+import os
+from urllib.parse import urlparse
+
+
+ENV_LIST_TEMPLATE = """\
+DISABLE_DEV_SHM_USAGE=true
+HEADLESS=true
+NO_SANDBOX=true
+PRINT_PAGE_SOURCE_ON_FAILURE=true
+ARCHIVE_BASE_URL=http://{host}:8800
+WEBVIEW_BASE_URL=http://{host}:8600
+# TODO: The stack doesn't include enough to test these yet...
+# LEGACY_BASE_URL=http://legacy-staging.cnx.org
+# NEB_ENV=staging
+"""
+
+
+def make_parser():
+    parser = argparse.ArgumentParser(description='Process some integers.')
+    parser.add_argument(
+        'dest',
+        help='destination server is being deployed as a url',
+    )
+    return parser
+
+
+def main():
+    parser = make_parser()
+    args = parser.parse_args()
+    host = urlparse(args.dest).netloc.split(':')[0]
+    print(ENV_LIST_TEMPLATE.format(host=host))
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
Provides pipeline rules for deploying cnx-archive to the staging stack, where the functional tests (cnx-automation) are run over it.

This feature is very similar to that which went into webview. In fact, they are running the same tests suite, just deploying a different service.