### PR TITLE
Add the prefix filter to the docker app configuration file

### DIFF
--- a/.dockerfiles/archive.ini
+++ b/.dockerfiles/archive.ini
@@ -1,5 +1,12 @@
+###
+# Use to pass through X-Forwarded-* headers (i.e. makes https work)
+###
+[filter:proxy-prefix]
+use = egg:PasteDeploy#prefix
+
 [app:main]
 use = egg:cnx-archive
+filter-with = proxy-prefix
 db-connection-string = dbname=repository user=rhaptos host=db port=5432
 # a list of memcache servers separated by whitespace
 # (memcache is disabled if no servers are given)


### PR DESCRIPTION
This allows the application to handle X-Forwarded-* headers,
which is necessary when we use a reverse proxy for SSL termination.