### PR TITLE
Rewrite portions of the recent.rss view and fix an error with the view

### DIFF
--- a/cnxarchive/tests/data/recent.rss
+++ b/cnxarchive/tests/data/recent.rss
@@ -22,9 +22,6 @@
             &lt;b&gt;
                   OpenStax College
             &lt;/b&gt;
-            &lt;br&gt;&lt;/br&gt;
-               
-            &lt;br&gt;&lt;/br&gt;
             &lt;img src="http://i.creativecommons.org/l/by/4.0/80x15.png" &gt;
             &lt;a href="http://creativecommons.org/licenses/by/4.0/"&gt;
               Some Rights Reserved
@@ -100,9 +97,6 @@
             &lt;b&gt;
                   OpenStax College
             &lt;/b&gt;
-            &lt;br&gt;&lt;/br&gt;
-               
-            &lt;br&gt;&lt;/br&gt;
             &lt;img src="http://i.creativecommons.org/l/by/4.0/80x15.png" &gt;
             &lt;a href="http://creativecommons.org/licenses/by/4.0/"&gt;
               Some Rights Reserved
@@ -126,9 +120,6 @@
             &lt;b&gt;
                   OpenStax College
             &lt;/b&gt;
-            &lt;br&gt;&lt;/br&gt;
-               
-            &lt;br&gt;&lt;/br&gt;
             &lt;img src="http://i.creativecommons.org/l/by/4.0/80x15.png" &gt;
             &lt;a href="http://creativecommons.org/licenses/by/4.0/"&gt;
               Some Rights Reserved
@@ -152,9 +143,6 @@
             &lt;b&gt;
                   OpenStax College
             &lt;/b&gt;
-            &lt;br&gt;&lt;/br&gt;
-               
-            &lt;br&gt;&lt;/br&gt;
             &lt;img src="http://i.creativecommons.org/l/by/4.0/80x15.png" &gt;
             &lt;a href="http://creativecommons.org/licenses/by/4.0/"&gt;
               Some Rights Reserved
@@ -178,9 +166,6 @@
             &lt;b&gt;
                   OpenStax College
             &lt;/b&gt;
-            &lt;br&gt;&lt;/br&gt;
-               
-            &lt;br&gt;&lt;/br&gt;
             &lt;img src="http://i.creativecommons.org/l/by/4.0/80x15.png" &gt;
             &lt;a href="http://creativecommons.org/licenses/by/4.0/"&gt;
               Some Rights Reserved
@@ -204,9 +189,6 @@
             &lt;b&gt;
                   OpenStax College
             &lt;/b&gt;
-            &lt;br&gt;&lt;/br&gt;
-               
-            &lt;br&gt;&lt;/br&gt;
             &lt;img src="http://i.creativecommons.org/l/by/4.0/80x15.png" &gt;
             &lt;a href="http://creativecommons.org/licenses/by/4.0/"&gt;
               Some Rights Reserved
@@ -230,9 +212,6 @@
             &lt;b&gt;
                   OpenStax College
             &lt;/b&gt;
-            &lt;br&gt;&lt;/br&gt;
-               
-            &lt;br&gt;&lt;/br&gt;
             &lt;img src="http://i.creativecommons.org/l/by/4.0/80x15.png" &gt;
             &lt;a href="http://creativecommons.org/licenses/by/4.0/"&gt;
               Some Rights Reserved
@@ -256,9 +235,6 @@
             &lt;b&gt;
                   OpenStax College
             &lt;/b&gt;
-            &lt;br&gt;&lt;/br&gt;
-               
-            &lt;br&gt;&lt;/br&gt;
             &lt;img src="http://i.creativecommons.org/l/by/4.0/80x15.png" &gt;
             &lt;a href="http://creativecommons.org/licenses/by/4.0/"&gt;
               Some Rights Reserved

--- a/cnxarchive/tests/data/recent.rss
+++ b/cnxarchive/tests/data/recent.rss
@@ -20,7 +20,7 @@
           &lt;/h3&gt;
           &lt;div class="feedEntryContent"&gt;
             &lt;b&gt;
-                  OpenStax College
+                  OpenStax Cöllege
             &lt;/b&gt;
             &lt;img src="http://i.creativecommons.org/l/by/4.0/80x15.png" &gt;
             &lt;a href="http://creativecommons.org/licenses/by/4.0/"&gt;
@@ -43,7 +43,7 @@
           &lt;/h3&gt;
           &lt;div class="feedEntryContent"&gt;
             &lt;b&gt;
-                  OpenStax College
+                  OpenStax Cöllege
             &lt;/b&gt;
             &lt;br&gt;&lt;/br&gt;
                This introductory, algebra-based, two-semester college physics book is grounded with real-world examples, illustrations, and explanations to help students grasp key, fundamental physics concepts. This online, fully editable and customizable title includes learning objectives, concept questions, links to labs and simulations, and ample practice opportunities to solve traditional physics application problems.
@@ -69,7 +69,7 @@
           &lt;/h3&gt;
           &lt;div class="feedEntryContent"&gt;
             &lt;b&gt;
-                  OpenStax College
+                  OpenStax Cöllege
             &lt;/b&gt;
             &lt;br&gt;&lt;/br&gt;
                This introductory, algebra-based, two-semester college physics book is grounded with real-world examples, illustrations, and explanations to help students grasp key, fundamental physics concepts. This online, fully editable and customizable title includes learning objectives, concept questions, links to labs and simulations, and ample practice opportunities to solve traditional physics application problems.
@@ -95,7 +95,7 @@
           &lt;/h3&gt;
           &lt;div class="feedEntryContent"&gt;
             &lt;b&gt;
-                  OpenStax College
+                  OpenStax Cöllege
             &lt;/b&gt;
             &lt;img src="http://i.creativecommons.org/l/by/4.0/80x15.png" &gt;
             &lt;a href="http://creativecommons.org/licenses/by/4.0/"&gt;
@@ -118,7 +118,7 @@
           &lt;/h3&gt;
           &lt;div class="feedEntryContent"&gt;
             &lt;b&gt;
-                  OpenStax College
+                  OpenStax Cöllege
             &lt;/b&gt;
             &lt;img src="http://i.creativecommons.org/l/by/4.0/80x15.png" &gt;
             &lt;a href="http://creativecommons.org/licenses/by/4.0/"&gt;
@@ -141,7 +141,7 @@
           &lt;/h3&gt;
           &lt;div class="feedEntryContent"&gt;
             &lt;b&gt;
-                  OpenStax College
+                  OpenStax Cöllege
             &lt;/b&gt;
             &lt;img src="http://i.creativecommons.org/l/by/4.0/80x15.png" &gt;
             &lt;a href="http://creativecommons.org/licenses/by/4.0/"&gt;
@@ -164,7 +164,7 @@
           &lt;/h3&gt;
           &lt;div class="feedEntryContent"&gt;
             &lt;b&gt;
-                  OpenStax College
+                  OpenStax Cöllege
             &lt;/b&gt;
             &lt;img src="http://i.creativecommons.org/l/by/4.0/80x15.png" &gt;
             &lt;a href="http://creativecommons.org/licenses/by/4.0/"&gt;
@@ -187,7 +187,7 @@
           &lt;/h3&gt;
           &lt;div class="feedEntryContent"&gt;
             &lt;b&gt;
-                  OpenStax College
+                  OpenStax Cöllege
             &lt;/b&gt;
             &lt;img src="http://i.creativecommons.org/l/by/4.0/80x15.png" &gt;
             &lt;a href="http://creativecommons.org/licenses/by/4.0/"&gt;
@@ -210,7 +210,7 @@
           &lt;/h3&gt;
           &lt;div class="feedEntryContent"&gt;
             &lt;b&gt;
-                  OpenStax College
+                  OpenStax Cöllege
             &lt;/b&gt;
             &lt;img src="http://i.creativecommons.org/l/by/4.0/80x15.png" &gt;
             &lt;a href="http://creativecommons.org/licenses/by/4.0/"&gt;
@@ -233,7 +233,7 @@
           &lt;/h3&gt;
           &lt;div class="feedEntryContent"&gt;
             &lt;b&gt;
-                  OpenStax College
+                  OpenStax Cöllege
             &lt;/b&gt;
             &lt;img src="http://i.creativecommons.org/l/by/4.0/80x15.png" &gt;
             &lt;a href="http://creativecommons.org/licenses/by/4.0/"&gt;

--- a/cnxarchive/tests/data/recent.rss
+++ b/cnxarchive/tests/data/recent.rss
@@ -20,7 +20,7 @@
           &lt;/h3&gt;
           &lt;div class="feedEntryContent"&gt;
             &lt;b&gt;
-                  OpenStax Cöllege
+                  OpenStax College
             &lt;/b&gt;
             &lt;br&gt;&lt;/br&gt;
                
@@ -46,7 +46,7 @@
           &lt;/h3&gt;
           &lt;div class="feedEntryContent"&gt;
             &lt;b&gt;
-                  OpenStax Cöllege
+                  OpenStax College
             &lt;/b&gt;
             &lt;br&gt;&lt;/br&gt;
                This introductory, algebra-based, two-semester college physics book is grounded with real-world examples, illustrations, and explanations to help students grasp key, fundamental physics concepts. This online, fully editable and customizable title includes learning objectives, concept questions, links to labs and simulations, and ample practice opportunities to solve traditional physics application problems.
@@ -72,7 +72,7 @@
           &lt;/h3&gt;
           &lt;div class="feedEntryContent"&gt;
             &lt;b&gt;
-                  OpenStax Cöllege
+                  OpenStax College
             &lt;/b&gt;
             &lt;br&gt;&lt;/br&gt;
                This introductory, algebra-based, two-semester college physics book is grounded with real-world examples, illustrations, and explanations to help students grasp key, fundamental physics concepts. This online, fully editable and customizable title includes learning objectives, concept questions, links to labs and simulations, and ample practice opportunities to solve traditional physics application problems.
@@ -98,7 +98,7 @@
           &lt;/h3&gt;
           &lt;div class="feedEntryContent"&gt;
             &lt;b&gt;
-                  OpenStax Cöllege
+                  OpenStax College
             &lt;/b&gt;
             &lt;br&gt;&lt;/br&gt;
                
@@ -124,7 +124,7 @@
           &lt;/h3&gt;
           &lt;div class="feedEntryContent"&gt;
             &lt;b&gt;
-                  OpenStax Cöllege
+                  OpenStax College
             &lt;/b&gt;
             &lt;br&gt;&lt;/br&gt;
                
@@ -150,7 +150,7 @@
           &lt;/h3&gt;
           &lt;div class="feedEntryContent"&gt;
             &lt;b&gt;
-                  OpenStax Cöllege
+                  OpenStax College
             &lt;/b&gt;
             &lt;br&gt;&lt;/br&gt;
                
@@ -176,7 +176,7 @@
           &lt;/h3&gt;
           &lt;div class="feedEntryContent"&gt;
             &lt;b&gt;
-                  OpenStax Cöllege
+                  OpenStax College
             &lt;/b&gt;
             &lt;br&gt;&lt;/br&gt;
                
@@ -202,7 +202,7 @@
           &lt;/h3&gt;
           &lt;div class="feedEntryContent"&gt;
             &lt;b&gt;
-                  OpenStax Cöllege
+                  OpenStax College
             &lt;/b&gt;
             &lt;br&gt;&lt;/br&gt;
                
@@ -228,7 +228,7 @@
           &lt;/h3&gt;
           &lt;div class="feedEntryContent"&gt;
             &lt;b&gt;
-                  OpenStax Cöllege
+                  OpenStax College
             &lt;/b&gt;
             &lt;br&gt;&lt;/br&gt;
                
@@ -254,7 +254,7 @@
           &lt;/h3&gt;
           &lt;div class="feedEntryContent"&gt;
             &lt;b&gt;
-                  OpenStax Cöllege
+                  OpenStax College
             &lt;/b&gt;
             &lt;br&gt;&lt;/br&gt;
                

--- a/cnxarchive/tests/data/recent.rss
+++ b/cnxarchive/tests/data/recent.rss
@@ -20,7 +20,7 @@
           &lt;/h3&gt;
           &lt;div class="feedEntryContent"&gt;
             &lt;b&gt;
-                  OpenStax Cöllege
+               OpenStax Cöllege
             &lt;/b&gt;
             &lt;img src="http://i.creativecommons.org/l/by/4.0/80x15.png" &gt;
             &lt;a href="http://creativecommons.org/licenses/by/4.0/"&gt;
@@ -43,7 +43,7 @@
           &lt;/h3&gt;
           &lt;div class="feedEntryContent"&gt;
             &lt;b&gt;
-                  OpenStax Cöllege
+               OpenStax Cöllege
             &lt;/b&gt;
             &lt;br&gt;&lt;/br&gt;
                This introductory, algebra-based, two-semester college physics book is grounded with real-world examples, illustrations, and explanations to help students grasp key, fundamental physics concepts. This online, fully editable and customizable title includes learning objectives, concept questions, links to labs and simulations, and ample practice opportunities to solve traditional physics application problems.
@@ -69,7 +69,7 @@
           &lt;/h3&gt;
           &lt;div class="feedEntryContent"&gt;
             &lt;b&gt;
-                  OpenStax Cöllege
+               OpenStax Cöllege
             &lt;/b&gt;
             &lt;br&gt;&lt;/br&gt;
                This introductory, algebra-based, two-semester college physics book is grounded with real-world examples, illustrations, and explanations to help students grasp key, fundamental physics concepts. This online, fully editable and customizable title includes learning objectives, concept questions, links to labs and simulations, and ample practice opportunities to solve traditional physics application problems.
@@ -95,7 +95,7 @@
           &lt;/h3&gt;
           &lt;div class="feedEntryContent"&gt;
             &lt;b&gt;
-                  OpenStax Cöllege
+               OpenStax Cöllege
             &lt;/b&gt;
             &lt;img src="http://i.creativecommons.org/l/by/4.0/80x15.png" &gt;
             &lt;a href="http://creativecommons.org/licenses/by/4.0/"&gt;
@@ -118,7 +118,7 @@
           &lt;/h3&gt;
           &lt;div class="feedEntryContent"&gt;
             &lt;b&gt;
-                  OpenStax Cöllege
+               OpenStax Cöllege
             &lt;/b&gt;
             &lt;img src="http://i.creativecommons.org/l/by/4.0/80x15.png" &gt;
             &lt;a href="http://creativecommons.org/licenses/by/4.0/"&gt;
@@ -141,7 +141,7 @@
           &lt;/h3&gt;
           &lt;div class="feedEntryContent"&gt;
             &lt;b&gt;
-                  OpenStax Cöllege
+               OpenStax Cöllege
             &lt;/b&gt;
             &lt;img src="http://i.creativecommons.org/l/by/4.0/80x15.png" &gt;
             &lt;a href="http://creativecommons.org/licenses/by/4.0/"&gt;
@@ -164,7 +164,7 @@
           &lt;/h3&gt;
           &lt;div class="feedEntryContent"&gt;
             &lt;b&gt;
-                  OpenStax Cöllege
+               OpenStax Cöllege
             &lt;/b&gt;
             &lt;img src="http://i.creativecommons.org/l/by/4.0/80x15.png" &gt;
             &lt;a href="http://creativecommons.org/licenses/by/4.0/"&gt;
@@ -187,7 +187,7 @@
           &lt;/h3&gt;
           &lt;div class="feedEntryContent"&gt;
             &lt;b&gt;
-                  OpenStax Cöllege
+               OpenStax Cöllege
             &lt;/b&gt;
             &lt;img src="http://i.creativecommons.org/l/by/4.0/80x15.png" &gt;
             &lt;a href="http://creativecommons.org/licenses/by/4.0/"&gt;
@@ -210,7 +210,7 @@
           &lt;/h3&gt;
           &lt;div class="feedEntryContent"&gt;
             &lt;b&gt;
-                  OpenStax Cöllege
+               OpenStax Cöllege
             &lt;/b&gt;
             &lt;img src="http://i.creativecommons.org/l/by/4.0/80x15.png" &gt;
             &lt;a href="http://creativecommons.org/licenses/by/4.0/"&gt;
@@ -233,7 +233,7 @@
           &lt;/h3&gt;
           &lt;div class="feedEntryContent"&gt;
             &lt;b&gt;
-                  OpenStax Cöllege
+               OpenStax Cöllege
             &lt;/b&gt;
             &lt;img src="http://i.creativecommons.org/l/by/4.0/80x15.png" &gt;
             &lt;a href="http://creativecommons.org/licenses/by/4.0/"&gt;

--- a/cnxarchive/tests/views/test_recent.py
+++ b/cnxarchive/tests/views/test_recent.py
@@ -72,7 +72,7 @@ class RecentRssViewTestCase(unittest.TestCase):
         # Stub the database interaction
         # FIXME: test for None abstract value
         row_info = [
-            ('intro', '<feb>', 'john, wanda', '<abstract>', 'id@1'),
+            ('intro', '<feb>', 'john, wanda', None, 'id@1'),
             ('book', '<mar>', 'jen, sal, harry', '<abstract>', 'id@5.1'),
         ]
         row_keys = ['name', 'revised', 'authors', 'abstract', 'ident_hash']

--- a/cnxarchive/tests/views/test_recent.py
+++ b/cnxarchive/tests/views/test_recent.py
@@ -44,25 +44,6 @@ class RecentViewsTestCase(unittest.TestCase):
         from ... import declare_type_info
         declare_type_info(config)
 
-        # Clear all cached searches
-        import memcache
-        mc_servers = self.settings['memcache-servers'].split()
-        mc = memcache.Client(mc_servers, debug=0)
-        mc.flush_all()
-        mc.disconnect_all()
-
-        # Patch database search so that it's possible to assert call counts
-        # later
-        from ... import cache
-        original_search = cache.database_search
-        self.db_search_call_count = 0
-
-        def patched_search(*args, **kwargs):
-            self.db_search_call_count += 1
-            return original_search(*args, **kwargs)
-        cache.database_search = patched_search
-        self.addCleanup(setattr, cache, 'database_search', original_search)
-
     def tearDown(self):
         pyramid_testing.tearDown()
         self.fixture.tearDown()

--- a/cnxarchive/tests/views/test_recent.py
+++ b/cnxarchive/tests/views/test_recent.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # ###
-# Copyright (c) 2013, Rice University
+# Copyright (c) 2013-2018, Rice University
 # This software is subject to the provisions of the GNU Affero General
 # Public License version 3 (AGPLv3).
 # See LICENCE.txt for details.
@@ -59,28 +59,6 @@ def monkeypatch_local_db_connect(test_case, new_func):
     test_case.addCleanup(setattr, recent, 'db_connect', original_func)
     setattr(recent, 'db_connect', new_func)
 
-
-class AuthorFormatTestCase(unittest.TestCase):
-
-    def test(self):
-        from cnxarchive import config
-        settings = {
-            config.CONNECTION_STRING: '<connection-string>'
-        }
-        authors = ['cnxcap', 'OpenStaxCollege']
-
-        # Stub the database interaction
-        db_results = [('OSC Physics Maintainer',), ('OpenStax College',)]
-        db_connect = stub_db_connect_database_interaction(db_results)
-
-        # Monkeypatch the db_connect function
-        monkeypatch_local_db_connect(self, db_connect)
-
-        # Call the target
-        from ...views.recent import format_author
-        formated = format_author(authors, settings)
-
-        self.assertEqual(formated, 'OSC Physics Maintainer, OpenStax College')
 
 
 class RecentViewsTestCase(unittest.TestCase):

--- a/cnxarchive/tests/views/test_recent.py
+++ b/cnxarchive/tests/views/test_recent.py
@@ -52,6 +52,14 @@ def stub_db_connect_database_interaction(results=[]):
     return db_connect
 
 
+def monkeypatch_local_db_connect(test_case, new_func):
+    # Monkeypatch the db_connect function
+    from ...views import recent
+    original_func = getattr(recent, 'db_connect')
+    test_case.addCleanup(setattr, recent, 'db_connect', original_func)
+    setattr(recent, 'db_connect', new_func)
+
+
 class AuthorFormatTestCase(unittest.TestCase):
 
     def test(self):
@@ -66,10 +74,7 @@ class AuthorFormatTestCase(unittest.TestCase):
         db_connect = stub_db_connect_database_interaction(db_results)
 
         # Monkeypatch the db_connect function
-        from ...views import recent
-        original_func = getattr(recent, 'db_connect')
-        self.addCleanup(setattr, recent, 'db_connect', original_func)
-        setattr(recent, 'db_connect', db_connect)
+        monkeypatch_local_db_connect(self, db_connect)
 
         # Call the target
         from ...views.recent import format_author

--- a/cnxarchive/utils/date.py
+++ b/cnxarchive/utils/date.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # ###
-# Copyright (c) 2013-2015, Rice University
+# Copyright (c) 2013-2018, Rice University
 # This software is subject to the provisions of the GNU Affero General
 # Public License version 3 (AGPLv3).
 # See LICENCE.txt for details.
@@ -10,9 +10,17 @@ import datetime
 import tzlocal
 
 
-__all__ = ('fromtimestamp',)
+__all__ = (
+    'fromtimestamp',
+    'rfc822',
+)
 
 
 def fromtimestamp(ts):
     """Convert a timestamp to a datetime using local timezone."""
     return datetime.datetime.fromtimestamp(ts, tz=tzlocal.get_localzone())
+
+
+def rfc822(dt):
+    """Converts a datatime object to string formatted according to RFC 822."""
+    return dt.strftime("%a, %d %b %Y %H:%M:%S %z")

--- a/cnxarchive/views/oai.py
+++ b/cnxarchive/views/oai.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # ###
-# Copyright (c) 2013, Rice University
+# Copyright (c) 2013-2018, Rice University
 # This software is subject to the provisions of the GNU Affero General
 # Public License version 3 (AGPLv3).
 # See LICENCE.txt for details.
@@ -13,12 +13,12 @@ from pyramid.view import view_config
 
 from .. import config
 from ..database import db_connect
-from .recent import html_rss_date
+from ..utils import rfc822
+
 
 # ################### #
 #     OAI HELPERS     #
 # ################### #
-
 
 def _setFromUntil(request):
     arguments = []
@@ -240,7 +240,7 @@ def oai(request):
     request.response.headers = {'Content-Type': 'text/xml; charset=UTF-8'}
 
     return_vars = {}
-    return_vars['dateTime'] = html_rss_date(datetime.now().time())
+    return_vars['dateTime'] = rfc822(datetime.now().time())
     return_vars['baseURL'] = request.path_url
     return_vars['host'] = request.host
     return_vars['query_request'] = []

--- a/cnxarchive/views/recent.py
+++ b/cnxarchive/views/recent.py
@@ -39,9 +39,9 @@ WITH recent_modules AS (
 SELECT
     name,
     revised,
-    (SELECT string_agg(u.full_name, ', ')
+    (SELECT string_agg(p.fullname, ', ')
      FROM (SELECT unnest(authors) AS author) AS _authors
-     JOIN users AS u ON (u.username = _authors.author)) as authors,
+     JOIN persons AS p ON (p.personid = _authors.author)) as authors,
     abstract,
     ident_hash
 FROM recent_modules;"""

--- a/cnxarchive/views/recent.py
+++ b/cnxarchive/views/recent.py
@@ -53,12 +53,15 @@ FROM recent_modules;"""
     modules = []
     for module in latest_module_results:
         abstract = module['abstract']
+        authors = module['authors']
         if abstract is not None:
             abstract = abstract.decode('utf-8')
+        if authors is not None:
+            authors = authors.decode('utf-8')
         modules.append({
             'name': module['name'].decode('utf-8'),
             'revised': rfc822(module['revised']),
-            'authors': module['authors'].decode('utf-8'),
+            'authors': authors,
             'abstract': abstract,
             'url': request.route_url('content',
                                      ident_hash=module['ident_hash']),

--- a/cnxarchive/views/recent.py
+++ b/cnxarchive/views/recent.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # ###
-# Copyright (c) 2013, Rice University
+# Copyright (c) 2013-2018, Rice University
 # This software is subject to the provisions of the GNU Affero General
 # Public License version 3 (AGPLv3).
 # See LICENCE.txt for details.
@@ -13,6 +13,7 @@ from pyramid.view import view_config
 
 from .. import config
 from ..database import db_connect
+from ..utils import rfc822
 
 logger = logging.getLogger('cnxarchive')
 
@@ -37,16 +38,6 @@ def format_author(personids, settings):
                 cursor.execute(statement, vars=(personids,))
                 authors_list = cursor.fetchall()
     return ', '.join([author[0] for author in authors_list]).decode('utf-8')
-
-
-def html_rss_date(datetime):
-    """
-    Return the HTTP-date format of python's datetime time.
-
-    Based on:
-    https://legacy.cnx.org/content/recent.rss
-    """
-    return datetime.strftime("%a, %d %b %Y %H:%M:%S %z")
 
 
 # #################### #
@@ -85,7 +76,7 @@ def recent(request):
     for module in latest_module_results:
         modules.append({
             'name': module['name'].decode('utf-8'),
-            'revised': html_rss_date(module['revised']),
+            'revised': rfc822(module['revised']),
             'authors': format_author(module['authors'], settings),
             'abstract': module['abstract'].decode('utf-8'),
             'url': request.route_url('content',

--- a/cnxarchive/views/recent.py
+++ b/cnxarchive/views/recent.py
@@ -52,11 +52,14 @@ FROM recent_modules;"""
                 latest_module_results = cur.fetchall()
     modules = []
     for module in latest_module_results:
+        abstract = module['abstract']
+        if abstract is not None:
+            abstract = abstract.decode('utf-8')
         modules.append({
             'name': module['name'].decode('utf-8'),
             'revised': rfc822(module['revised']),
             'authors': module['authors'].decode('utf-8'),
-            'abstract': module['abstract'].decode('utf-8'),
+            'abstract': abstract,
             'url': request.route_url('content',
                                      ident_hash=module['ident_hash']),
         })

--- a/cnxarchive/views/recent.py
+++ b/cnxarchive/views/recent.py
@@ -25,7 +25,6 @@ def recent(request):
     if portal_type != ['Collection', 'Module']:
         portal_type = [portal_type]
     # search the database
-    settings = request.registry.settings
     statement = """\
 WITH recent_modules AS (
     SELECT

--- a/cnxarchive/views/recent.py
+++ b/cnxarchive/views/recent.py
@@ -6,17 +6,12 @@
 # See LICENCE.txt for details.
 # ###
 """Recent RSS feed View."""
-import logging
-
 import psycopg2.extras
 from pyramid.view import view_config
 
 from .. import config
 from ..database import db_connect
 from ..utils import rfc822
-
-
-logger = logging.getLogger('cnxarchive')
 
 
 @view_config(route_name='recent', request_method='GET',

--- a/cnxarchive/views/templates/recent.rss
+++ b/cnxarchive/views/templates/recent.rss
@@ -19,9 +19,11 @@
             &lt;/div&gt;
           &lt;/h3&gt;
           &lt;div class="feedEntryContent"&gt;
+            {%- if module.authors %}
             &lt;b&gt;
-                  {{module.authors}}
+               {{ module.authors }}
             &lt;/b&gt;
+            {%- endif %}
             {%- if module.abstract %}
             &lt;br&gt;&lt;/br&gt;
                {{ module.abstract }}

--- a/cnxarchive/views/templates/recent.rss
+++ b/cnxarchive/views/templates/recent.rss
@@ -22,9 +22,11 @@
             &lt;b&gt;
                   {{module.authors}}
             &lt;/b&gt;
+            {%- if module.abstract %}
             &lt;br&gt;&lt;/br&gt;
-               {{module.abstract}}
+               {{ module.abstract }}
             &lt;br&gt;&lt;/br&gt;
+            {%- endif %}
             &lt;img src="http://i.creativecommons.org/l/by/4.0/80x15.png" &gt;
             &lt;a href="http://creativecommons.org/licenses/by/4.0/"&gt;
               Some Rights Reserved

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,8 @@ install_requires = (
     'waitress',  # wsgi server
     )
 tests_require = [
-    'webtest<=2.0.27'
+    'webtest<=2.0.27',
+    'pretend',
     ]
 description = "An archive for Connexions documents."
 


### PR DESCRIPTION
This rewrites the database query that populates the content for the `recent.rss` file. The database query has been condensed from 1+(n*result) to 1. This refactoring eliminated some formatting logic.

The primary and original purpose of this changeset was to fix #620, which thankful is covered in this changeset.

As an added bonus, I fixed an issue with the authors lookup too. Some of the way old content has no authors, which causes failures. This fixes that as well.

Fixes #620 